### PR TITLE
Fix scroll animation: remove shrinking animation and stop after tick

### DIFF
--- a/msc-ca-fresher-program/script.js
+++ b/msc-ca-fresher-program/script.js
@@ -529,18 +529,19 @@ const initializeBenefitsScrollytelling = () => {
 
     // --- LOTTIE SCRUB ---
     try {
-      // The Lottie animation is driven linearly by the scroll progress.
-      // We want the full animation (all the way to 1.0) so the tickmarks 
-      // appear at the very bottom.
-      const adjustedProgress = progress;
+      const END_FRAME_RATIO = 0.7; // Finishes before the shrinking begins
 
       if (lottiePlayer.getLottie) {
         const anim = lottiePlayer.getLottie();
         if (anim && anim.totalFrames) {
-          anim.goToAndStop(adjustedProgress * anim.totalFrames, true);
+          const END_FRAME = anim.totalFrames * END_FRAME_RATIO;
+          const frame = progress * END_FRAME;
+          const clampedFrame = Math.min(frame, END_FRAME);
+          anim.goToAndStop(clampedFrame, true);
         }
       } else if (lottiePlayer.seek) {
-        lottiePlayer.seek(adjustedProgress * 100 + '%');
+        const endPercent = END_FRAME_RATIO * 100;
+        lottiePlayer.seek(Math.min(progress * endPercent, endPercent) + '%');
       }
     } catch (e) { }
 


### PR DESCRIPTION
This pull request fixes the scroll-controlled Lottie animation behavior in the website.

Previously, the animation continued playing additional frames after the tick mark appeared, causing an unintended shrinking animation. The animation also did not align well with the scroll progression of the slides.

Changes made:

* Limited the animation frame range so it stops immediately after the tick animation completes.
* Removed the shrinking animation that played after the tick.
* Adjusted the scroll-to-animation mapping so the animation progresses smoothly and completes at the final slide of the section.

This update ensures a cleaner and more intuitive scroll animation experience while maintaining the intended visual flow of the section.