### PR TITLE
Improve AI refine flow with custom prompts, preview diff, and prompt …

### DIFF
--- a/cv-builder/cv-script.js
+++ b/cv-builder/cv-script.js
@@ -2119,7 +2119,7 @@ async function printCV() {
 }
 
         // AI & Import Logic
-        async function refineSection(fieldType, text) {
+        async function refineSection(fieldType, text, customPrompt = '') {
             const trimmed = (text || '').trim();
             if (!trimmed) throw new Error('Nothing to refine');
 
@@ -2129,7 +2129,7 @@ async function printCV() {
             const response = await fetch(`${WORKER_URL}/refine-section`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ text: trimmed, field_type: fieldType, template_id: templateId })
+                body: JSON.stringify({ text: trimmed, field_type: fieldType, template_id: templateId, custom_prompt: customPrompt || '' })
             });
             const res = await response.json();
             if (!res.ok || !res.refined_text) {
@@ -2138,11 +2138,300 @@ async function printCV() {
             return res.refined_text;
         }
 
+        const AI_PROMPT_SUGGESTIONS = {
+            default: [
+                'Make it concise and ATS-friendly',
+                'Use stronger action verbs',
+                'Improve clarity but keep original meaning'
+            ],
+            Summary: [
+                'Keep it under 60 words',
+                'Focus on CA articleship impact',
+                'Make it ATS-friendly and concise'
+            ],
+            Skills: [
+                'Group skills by category',
+                'Prioritize audit, tax, and compliance skills',
+                'Keep clean comma-separated format'
+            ],
+            Experience: [
+                'Add measurable impact where possible',
+                'Keep exactly same bullet count',
+                'Make each bullet one strong line'
+            ],
+            Projects: [
+                'Highlight outcomes and tools used',
+                'Make bullets results-focused',
+                'Keep project language concise'
+            ],
+            Achievements: [
+                'Make each point quantifiable',
+                'Keep strong achievement-focused wording',
+                'Use action-first phrasing'
+            ],
+            Leadership: [
+                'Show ownership and initiative clearly',
+                'Keep points concise and outcome-based',
+                'Use leadership-oriented language'
+            ],
+            Interests: [
+                'Keep it professional and clean',
+                'Shorten each item to one line',
+                'Improve readability for recruiters'
+            ]
+        };
+
+        let aiPromptResolver = null;
+        let aiPreviewResolver = null;
+
+        function toPreviewText(value) {
+            return String(value || '').replace(/\r/g, '').trim();
+        }
+
+        function escapeHtml(value) {
+            return String(value || '')
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#39;');
+        }
+
+        function splitPreviewLines(value) {
+            const text = toPreviewText(value);
+            if (!text) return [];
+            const parts = text.split('\n').map(line => line.trimEnd());
+            return parts.length ? parts : [text];
+        }
+
+        function buildLineDiff(beforeText, afterText) {
+            const beforeLines = splitPreviewLines(beforeText);
+            const afterLines = splitPreviewLines(afterText);
+            const n = beforeLines.length;
+            const m = afterLines.length;
+            const dp = Array.from({ length: n + 1 }, () => new Array(m + 1).fill(0));
+
+            for (let i = n - 1; i >= 0; i--) {
+                for (let j = m - 1; j >= 0; j--) {
+                    if (beforeLines[i] === afterLines[j]) dp[i][j] = dp[i + 1][j + 1] + 1;
+                    else dp[i][j] = Math.max(dp[i + 1][j], dp[i][j + 1]);
+                }
+            }
+
+            const beforeStates = new Array(n).fill('removed');
+            const afterStates = new Array(m).fill('added');
+
+            let i = 0;
+            let j = 0;
+            while (i < n && j < m) {
+                if (beforeLines[i] === afterLines[j]) {
+                    beforeStates[i] = 'unchanged';
+                    afterStates[j] = 'unchanged';
+                    i++;
+                    j++;
+                } else if (dp[i + 1][j] >= dp[i][j + 1]) {
+                    i++;
+                } else {
+                    j++;
+                }
+            }
+
+            return {
+                before: beforeLines.map((line, idx) => ({ line, type: beforeStates[idx] })),
+                after: afterLines.map((line, idx) => ({ line, type: afterStates[idx] }))
+            };
+        }
+
+        function renderDiffPanel(el, entries, emptyLabel) {
+            if (!el) return;
+            if (!entries.length) {
+                el.innerHTML = `<span class="diff-line diff-empty">${escapeHtml(emptyLabel || '(empty)')}</span>`;
+                return;
+            }
+            el.innerHTML = entries.map((entry) => {
+                const cls = entry.type === 'added'
+                    ? 'diff-added'
+                    : entry.type === 'removed'
+                        ? 'diff-removed'
+                        : 'diff-unchanged';
+                return `<span class="diff-line ${cls}">${escapeHtml(entry.line || ' ')}</span>`;
+            }).join('');
+        }
+
+        function listToPreviewText(items) {
+            const arr = Array.isArray(items) ? items : [];
+            return arr.map((item, idx) => `${idx + 1}. ${String(item || '').trim()}`).join('\n');
+        }
+
+        function setAiPromptSuggestions(sectionLabel = '') {
+            const host = document.getElementById('ai-prompt-suggestions');
+            if (!host) return;
+            host.innerHTML = '';
+            const suggestions = AI_PROMPT_SUGGESTIONS[sectionLabel] || AI_PROMPT_SUGGESTIONS.default;
+            suggestions.forEach((text) => {
+                const btn = document.createElement('button');
+                btn.type = 'button';
+                btn.className = 'ai-prompt-chip';
+                btn.textContent = text;
+                btn.onclick = () => {
+                    const input = document.getElementById('ai-prompt-input');
+                    if (!input) return;
+                    input.value = input.value ? `${input.value.trim()} ${text}` : text;
+                    input.focus();
+                };
+                host.appendChild(btn);
+            });
+        }
+
+        function handleAiPromptOverlayClick(event) {
+            const overlay = document.getElementById('ai-prompt-overlay');
+            if (!overlay) return;
+            if (event.target === overlay) closeAiPrompt('cancel');
+        }
+
+        function openAiPromptModal(sectionLabel = '') {
+            const overlay = document.getElementById('ai-prompt-overlay');
+            const input = document.getElementById('ai-prompt-input');
+            const title = document.getElementById('ai-prompt-title');
+            if (!overlay || !input || !title) return Promise.resolve('');
+
+            const label = sectionLabel ? ` for ${sectionLabel}` : '';
+            title.textContent = `Optional AI instruction${label}`;
+            input.value = '';
+            setAiPromptSuggestions(sectionLabel);
+
+            overlay.classList.add('open');
+            overlay.setAttribute('aria-hidden', 'false');
+
+            return new Promise((resolve) => {
+                aiPromptResolver = resolve;
+                setTimeout(() => input.focus(), 0);
+            });
+        }
+
+        function closeAiPrompt(action = 'cancel') {
+            const overlay = document.getElementById('ai-prompt-overlay');
+            const input = document.getElementById('ai-prompt-input');
+            if (!overlay || !input) return;
+            if (!aiPromptResolver) {
+                overlay.classList.remove('open');
+                overlay.setAttribute('aria-hidden', 'true');
+                return;
+            }
+            let value = null;
+            if (action === 'apply') {
+                value = String(input.value || '').trim();
+            } else if (action === 'skip') {
+                value = '';
+            } else {
+                value = null;
+            }
+            const resolve = aiPromptResolver;
+            aiPromptResolver = null;
+            overlay.classList.remove('open');
+            overlay.setAttribute('aria-hidden', 'true');
+            resolve(value);
+        }
+
+        function submitAiPrompt() {
+            closeAiPrompt('apply');
+        }
+
+        function skipAiPrompt() {
+            closeAiPrompt('skip');
+        }
+
+        async function getCustomPrompt(sectionLabel) {
+            return await openAiPromptModal(sectionLabel);
+        }
+
+        function handleAiPreviewOverlayClick(event) {
+            const overlay = document.getElementById('ai-preview-overlay');
+            if (!overlay) return;
+            if (event.target === overlay) closeAiPreview(false);
+        }
+
+        function openAiPreviewModal({ title, before, after, beforeLabel = 'Before', afterLabel = 'After' }) {
+            const overlay = document.getElementById('ai-preview-overlay');
+            const titleEl = document.getElementById('ai-preview-title');
+            const beforeEl = document.getElementById('ai-preview-before');
+            const afterEl = document.getElementById('ai-preview-after');
+            const beforeLabelEl = document.getElementById('ai-preview-before-label');
+            const afterLabelEl = document.getElementById('ai-preview-after-label');
+            if (!overlay || !titleEl || !beforeEl || !afterEl || !beforeLabelEl || !afterLabelEl) return Promise.resolve(true);
+
+            titleEl.textContent = title || 'Review AI changes';
+            beforeLabelEl.textContent = beforeLabel;
+            afterLabelEl.textContent = afterLabel;
+
+            const beforeText = toPreviewText(before);
+            const afterText = toPreviewText(after);
+            const diff = buildLineDiff(beforeText, afterText);
+            renderDiffPanel(beforeEl, diff.before, '(empty)');
+            renderDiffPanel(afterEl, diff.after, '(empty)');
+
+            overlay.classList.add('open');
+            overlay.setAttribute('aria-hidden', 'false');
+
+            return new Promise((resolve) => {
+                aiPreviewResolver = resolve;
+            });
+        }
+
+        function closeAiPreview(accept) {
+            const overlay = document.getElementById('ai-preview-overlay');
+            if (!overlay) return;
+            if (!aiPreviewResolver) {
+                overlay.classList.remove('open');
+                overlay.setAttribute('aria-hidden', 'true');
+                return;
+            }
+            const resolve = aiPreviewResolver;
+            aiPreviewResolver = null;
+            overlay.classList.remove('open');
+            overlay.setAttribute('aria-hidden', 'true');
+            resolve(Boolean(accept));
+        }
+
+        window.addEventListener('keydown', (event) => {
+            if (!aiPromptResolver) return;
+            if (event.key === 'Escape') {
+                event.preventDefault();
+                closeAiPrompt('cancel');
+            }
+            if ((event.ctrlKey || event.metaKey) && event.key === 'Enter') {
+                event.preventDefault();
+                submitAiPrompt();
+            }
+        });
+
+        window.addEventListener('keydown', (event) => {
+            if (!aiPreviewResolver) return;
+            if (event.key === 'Escape') {
+                event.preventDefault();
+                closeAiPreview(false);
+            }
+            if ((event.ctrlKey || event.metaKey) && event.key === 'Enter') {
+                event.preventDefault();
+                closeAiPreview(true);
+            }
+        });
+
         async function aiRefineSummary() {
             try {
+                const customPrompt = await getCustomPrompt('Summary');
+                if (customPrompt === null) return;
                 const overlay = document.querySelector('.loading-overlay');
                 overlay?.classList.add('active');
-                const refined = await refineSection('summary', getSummaryPlainText() || cvData.summary);
+                const refined = await refineSection('summary', getSummaryPlainText() || cvData.summary, customPrompt);
+                overlay?.classList.remove('active');
+                const originalText = getSummaryPlainText() || getPlainTextFromHTML(cvData.summary || '');
+                const refinedText = getPlainTextFromHTML(sanitizeSummaryHTML(refined));
+                const approved = await openAiPreviewModal({ title: 'Apply AI changes to Summary?', before: originalText, after: refinedText });
+                if (!approved) {
+                    showToast('AI changes discarded');
+                    return;
+                }
                 cvData.summary = sanitizeSummaryHTML(refined);
                 setSummaryEditorValue(cvData.summary);
                 updateCV();
@@ -2157,9 +2446,19 @@ async function printCV() {
 
         async function aiRefineSkills() {
             try {
+                const customPrompt = await getCustomPrompt('Skills');
+                if (customPrompt === null) return;
                 const overlay = document.querySelector('.loading-overlay');
                 overlay?.classList.add('active');
-                const refined = await refineSection('skills', getSkillsPlainText() || cvData.skills);
+                const refined = await refineSection('skills', getSkillsPlainText() || cvData.skills, customPrompt);
+                overlay?.classList.remove('active');
+                const originalText = getSkillsPlainText() || getPlainTextFromHTML(cvData.skills || '');
+                const refinedText = getPlainTextFromHTML(sanitizeSummaryHTML(refined));
+                const approved = await openAiPreviewModal({ title: 'Apply AI changes to Skills?', before: originalText, after: refinedText });
+                if (!approved) {
+                    showToast('AI changes discarded');
+                    return;
+                }
                 cvData.skills = sanitizeSummaryHTML(refined);
                 setSkillsEditorValue(cvData.skills);
                 updateCV();
@@ -2177,14 +2476,168 @@ async function printCV() {
                 if (!cvData.experience || !cvData.experience[index]) throw new Error('Experience not found');
                 const bullets = cvData.experience[index].bullets || [];
                 const raw = bullets.join('\n');
+                const customPrompt = await getCustomPrompt('Experience');
+                if (customPrompt === null) return;
                 const overlay = document.querySelector('.loading-overlay');
                 overlay?.classList.add('active');
-                const refined = await refineSection('bullets', raw);
+                const refined = await refineSection('experience_bullets', raw, customPrompt);
                 const refinedLines = refined.split('\n').map(l => l.trim()).filter(Boolean);
+                overlay?.classList.remove('active');
+                const approved = await openAiPreviewModal({
+                    title: 'Apply AI changes to Experience?',
+                    before: listToPreviewText(bullets),
+                    after: listToPreviewText(refinedLines)
+                });
+                if (!approved) {
+                    showToast('AI changes discarded');
+                    return;
+                }
                 cvData.experience[index].bullets = refinedLines;
                 renderExpInputs();
                 postToFrame();
                 showToast('Experience refined');
+            } catch (e) {
+                alert('AI refine failed: ' + e.message);
+            } finally {
+                const overlay = document.querySelector('.loading-overlay');
+                overlay?.classList.remove('active');
+            }
+        }
+
+        async function aiRefineProjects() {
+            try {
+                if (!cvData.projects || !cvData.projects.length) throw new Error('No projects found');
+                const customPrompt = await getCustomPrompt('Projects');
+                if (customPrompt === null) return;
+                const overlay = document.querySelector('.loading-overlay');
+                overlay?.classList.add('active');
+                const beforePreview = [];
+                const afterPreview = [];
+                for (let i = 0; i < cvData.projects.length; i++) {
+                    const proj = cvData.projects[i];
+                    const bullets = Array.isArray(proj.bullets) ? proj.bullets : [];
+                    if (!bullets.length) continue;
+                    const raw = bullets.join('\n');
+                    const refined = await refineSection('project_bullets', raw, customPrompt);
+                    const refinedLines = refined.split('\n').map(l => l.trim()).filter(Boolean);
+                    beforePreview.push(`${proj.title || `Project ${i + 1}`}\n${listToPreviewText(bullets)}`);
+                    afterPreview.push(`${proj.title || `Project ${i + 1}`}\n${listToPreviewText(refinedLines)}`);
+                    proj.__pendingRefinedBullets = refinedLines;
+                }
+                overlay?.classList.remove('active');
+                const approved = await openAiPreviewModal({
+                    title: 'Apply AI changes to Projects?',
+                    before: beforePreview.join('\n\n'),
+                    after: afterPreview.join('\n\n')
+                });
+                if (!approved) {
+                    cvData.projects.forEach((proj) => delete proj.__pendingRefinedBullets);
+                    showToast('AI changes discarded');
+                    return;
+                }
+                cvData.projects.forEach((proj) => {
+                    if (Array.isArray(proj.__pendingRefinedBullets)) proj.bullets = proj.__pendingRefinedBullets;
+                    delete proj.__pendingRefinedBullets;
+                });
+                renderProjInputs();
+                postToFrame();
+                showToast('Projects refined');
+            } catch (e) {
+                alert('AI refine failed: ' + e.message);
+            } finally {
+                const overlay = document.querySelector('.loading-overlay');
+                overlay?.classList.remove('active');
+            }
+        }
+
+        async function aiRefineAchievements() {
+            try {
+                const items = Array.isArray(cvData.achievements) ? cvData.achievements : [];
+                if (!items.length) throw new Error('No achievements found');
+                const customPrompt = await getCustomPrompt('Achievements');
+                if (customPrompt === null) return;
+                const overlay = document.querySelector('.loading-overlay');
+                overlay?.classList.add('active');
+                const refined = await refineSection('achievements', items.join('\n'), customPrompt);
+                const refinedItems = refined.split('\n').map(l => l.trim()).filter(Boolean);
+                overlay?.classList.remove('active');
+                const approved = await openAiPreviewModal({
+                    title: 'Apply AI changes to Achievements?',
+                    before: listToPreviewText(items),
+                    after: listToPreviewText(refinedItems)
+                });
+                if (!approved) {
+                    showToast('AI changes discarded');
+                    return;
+                }
+                cvData.achievements = refinedItems;
+                renderListInputs('achievements', 'ach-container', 'achievements');
+                postToFrame();
+                showToast('Achievements refined');
+            } catch (e) {
+                alert('AI refine failed: ' + e.message);
+            } finally {
+                const overlay = document.querySelector('.loading-overlay');
+                overlay?.classList.remove('active');
+            }
+        }
+
+        async function aiRefineLeadership() {
+            try {
+                const items = Array.isArray(cvData.leadership) ? cvData.leadership : [];
+                if (!items.length) throw new Error('No leadership items found');
+                const customPrompt = await getCustomPrompt('Leadership');
+                if (customPrompt === null) return;
+                const overlay = document.querySelector('.loading-overlay');
+                overlay?.classList.add('active');
+                const refined = await refineSection('leadership', items.join('\n'), customPrompt);
+                const refinedItems = refined.split('\n').map(l => l.trim()).filter(Boolean);
+                overlay?.classList.remove('active');
+                const approved = await openAiPreviewModal({
+                    title: 'Apply AI changes to Leadership?',
+                    before: listToPreviewText(items),
+                    after: listToPreviewText(refinedItems)
+                });
+                if (!approved) {
+                    showToast('AI changes discarded');
+                    return;
+                }
+                cvData.leadership = refinedItems;
+                renderListInputs('leadership', 'lead-container', 'leadership');
+                postToFrame();
+                showToast('Leadership refined');
+            } catch (e) {
+                alert('AI refine failed: ' + e.message);
+            } finally {
+                const overlay = document.querySelector('.loading-overlay');
+                overlay?.classList.remove('active');
+            }
+        }
+
+        async function aiRefineInterests() {
+            try {
+                const items = Array.isArray(cvData.interests) ? cvData.interests : [];
+                if (!items.length) throw new Error('No interests found');
+                const customPrompt = await getCustomPrompt('Interests');
+                if (customPrompt === null) return;
+                const overlay = document.querySelector('.loading-overlay');
+                overlay?.classList.add('active');
+                const refined = await refineSection('interests', items.join('\n'), customPrompt);
+                const refinedItems = refined.split('\n').map(l => l.trim()).filter(Boolean);
+                overlay?.classList.remove('active');
+                const approved = await openAiPreviewModal({
+                    title: 'Apply AI changes to Interests?',
+                    before: listToPreviewText(items),
+                    after: listToPreviewText(refinedItems)
+                });
+                if (!approved) {
+                    showToast('AI changes discarded');
+                    return;
+                }
+                cvData.interests = refinedItems;
+                renderListInputs('interests', 'int-container', 'interests');
+                postToFrame();
+                showToast('Interests refined');
             } catch (e) {
                 alert('AI refine failed: ' + e.message);
             } finally {

--- a/cv-builder/cv-styles.css
+++ b/cv-builder/cv-styles.css
@@ -1461,10 +1461,248 @@
             backdrop-filter: blur(2px);
         }
 
-        .loading-overlay.active {
-            opacity: 1;
-            pointer-events: all;
-        }
+.loading-overlay.active {
+    opacity: 1;
+    pointer-events: all;
+}
+
+.ai-prompt-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.45);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s ease;
+    z-index: 1400;
+    padding: 20px;
+}
+
+.ai-prompt-overlay.open {
+    opacity: 1;
+    pointer-events: all;
+}
+
+.ai-prompt-card {
+    width: min(92vw, 440px);
+    background: #fff;
+    border-radius: 16px;
+    padding: 18px 18px 16px;
+    box-shadow: 0 22px 50px rgba(15, 23, 42, 0.18);
+    border: 1px solid rgba(148, 163, 184, 0.4);
+}
+
+.ai-prompt-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.ai-prompt-header h3 {
+    margin: 0;
+    font-size: 16px;
+    font-weight: 600;
+    color: #0f172a;
+}
+
+.ai-prompt-close {
+    border: none;
+    background: #f8fafc;
+    color: #0f172a;
+    width: 28px;
+    height: 28px;
+    border-radius: 999px;
+    font-size: 18px;
+    line-height: 1;
+    cursor: pointer;
+}
+
+.ai-prompt-sub {
+    margin: 8px 0 12px;
+    font-size: 12px;
+    color: #64748b;
+}
+
+.ai-prompt-suggestions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin: 0 0 10px;
+}
+
+.ai-prompt-chip {
+    border: 1px solid #dbe5f5;
+    background: #f8fbff;
+    color: #1f3f74;
+    border-radius: 999px;
+    padding: 6px 10px;
+    font-size: 12px;
+    font-weight: 600;
+    cursor: pointer;
+    line-height: 1;
+}
+
+.ai-prompt-chip:hover {
+    background: #eef5ff;
+    border-color: #c8d8f2;
+}
+
+.ai-prompt-card textarea.form-control {
+    min-height: 90px;
+    resize: vertical;
+}
+
+.ai-prompt-actions {
+    display: flex;
+    gap: 10px;
+    justify-content: flex-end;
+    margin-top: 12px;
+}
+
+.ai-preview-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.45);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s ease;
+    z-index: 1450;
+    padding: 20px;
+}
+
+.ai-preview-overlay.open {
+    opacity: 1;
+    pointer-events: all;
+}
+
+.ai-preview-card {
+    width: min(94vw, 920px);
+    background: #fff;
+    border-radius: 16px;
+    border: 1px solid rgba(148, 163, 184, 0.4);
+    box-shadow: 0 22px 50px rgba(15, 23, 42, 0.18);
+    padding: 16px;
+}
+
+.ai-preview-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 12px;
+}
+
+.ai-preview-header h3 {
+    margin: 0;
+    font-size: 16px;
+    font-weight: 700;
+    color: #0f172a;
+}
+
+.ai-preview-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+}
+
+.ai-preview-pane {
+    border: 1px solid #e2e8f0;
+    border-radius: 12px;
+    background: #f8fafc;
+    min-height: 220px;
+    display: flex;
+    flex-direction: column;
+}
+
+.ai-preview-label {
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+    color: #64748b;
+    border-bottom: 1px solid #e2e8f0;
+    padding: 10px 12px;
+}
+
+.ai-preview-content {
+    margin: 0;
+    padding: 12px;
+    font-family: inherit;
+    font-size: 13px;
+    line-height: 1.45;
+    color: #0f172a;
+    white-space: pre-wrap;
+    overflow: auto;
+    max-height: min(56vh, 420px);
+}
+
+.diff-line {
+    display: block;
+    padding: 3px 6px;
+    border-radius: 6px;
+    margin-bottom: 2px;
+}
+
+.diff-unchanged {
+    background: transparent;
+}
+
+.diff-added {
+    background: #ecfdf3;
+    color: #065f46;
+    border-left: 3px solid #22c55e;
+}
+
+.diff-removed {
+    background: #fef2f2;
+    color: #991b1b;
+    border-left: 3px solid #ef4444;
+}
+
+.diff-empty {
+    color: #94a3b8;
+    font-style: italic;
+}
+
+@media (max-width: 640px) {
+    .ai-prompt-overlay {
+        padding: 12px;
+        align-items: flex-end;
+    }
+
+    .ai-prompt-card {
+        width: 100%;
+        border-radius: 18px 18px 10px 10px;
+        padding: 16px;
+    }
+
+    .ai-preview-overlay {
+        padding: 10px;
+        align-items: flex-end;
+    }
+
+    .ai-preview-card {
+        width: 100%;
+        border-radius: 16px 16px 10px 10px;
+        padding: 12px;
+    }
+
+    .ai-preview-grid {
+        grid-template-columns: 1fr;
+        gap: 10px;
+    }
+
+    .ai-preview-content {
+        max-height: 32vh;
+        font-size: 12px;
+    }
+}
 
         .spinner {
             width: 36px;

--- a/cv-builder/index.html
+++ b/cv-builder/index.html
@@ -227,6 +227,17 @@
             <details data-section="projects">
                 <summary>Projects</summary>
                 <div class="section-body">
+                    <div class="form-group">
+                        <div style="display:flex; align-items:center; justify-content:space-between; margin-bottom:6px;">
+                            <label style="margin-bottom:0;">Projects (All)</label>
+                            <button type="button" class="btn-mini" onclick="aiRefineProjects()" title="Refine project bullets with AI">
+                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <path d="M12 3l2.09 4.26L19 8l-3.5 3.4L16.18 17 12 14.8 7.82 17 9 11.4 5 8l4.91-.74L12 3z"></path>
+                                </svg>
+                                AI refine
+                            </button>
+                        </div>
+                    </div>
                     <div id="proj-container"></div>
                     <button class="btn-dashed" onclick="addProject()">
                         <svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2"
@@ -257,6 +268,17 @@
             <details data-section="achievements">
                 <summary>Achievements & Awards</summary>
                 <div class="section-body">
+                    <div class="form-group">
+                        <div style="display:flex; align-items:center; justify-content:space-between; margin-bottom:6px;">
+                            <label style="margin-bottom:0;">Achievements (All)</label>
+                            <button type="button" class="btn-mini" onclick="aiRefineAchievements()" title="Refine achievements with AI">
+                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <path d="M12 3l2.09 4.26L19 8l-3.5 3.4L16.18 17 12 14.8 7.82 17 9 11.4 5 8l4.91-.74L12 3z"></path>
+                                </svg>
+                                AI refine
+                            </button>
+                        </div>
+                    </div>
                     <div id="ach-container"></div>
                     <button class="btn-dashed" onclick="addListItem('achievements')">
                         <svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2"
@@ -272,6 +294,17 @@
             <details data-section="leadership">
                 <summary>Leadership</summary>
                 <div class="section-body">
+                    <div class="form-group">
+                        <div style="display:flex; align-items:center; justify-content:space-between; margin-bottom:6px;">
+                            <label style="margin-bottom:0;">Leadership (All)</label>
+                            <button type="button" class="btn-mini" onclick="aiRefineLeadership()" title="Refine leadership items with AI">
+                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <path d="M12 3l2.09 4.26L19 8l-3.5 3.4L16.18 17 12 14.8 7.82 17 9 11.4 5 8l4.91-.74L12 3z"></path>
+                                </svg>
+                                AI refine
+                            </button>
+                        </div>
+                    </div>
                     <div id="lead-container"></div>
                     <button class="btn-dashed" onclick="addListItem('leadership')">
                         <svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2"
@@ -287,6 +320,17 @@
             <details data-section="interests">
                 <summary>Interests & Hobbies</summary>
                 <div class="section-body">
+                    <div class="form-group">
+                        <div style="display:flex; align-items:center; justify-content:space-between; margin-bottom:6px;">
+                            <label style="margin-bottom:0;">Interests (All)</label>
+                            <button type="button" class="btn-mini" onclick="aiRefineInterests()" title="Refine interests with AI">
+                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <path d="M12 3l2.09 4.26L19 8l-3.5 3.4L16.18 17 12 14.8 7.82 17 9 11.4 5 8l4.91-.74L12 3z"></path>
+                                </svg>
+                                AI refine
+                            </button>
+                        </div>
+                    </div>
                     <div id="int-container"></div>
                     <button class="btn-dashed" onclick="addListItem('interests')">
                         <svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2"
@@ -407,6 +451,45 @@
             <iframe id="cv-frame" src="cv2.html"></iframe>
             <div id="ai-spinner" class="loading-overlay">
                 <div class="spinner"></div>
+            </div>
+        </div>
+        <div id="ai-prompt-overlay" class="ai-prompt-overlay" aria-hidden="true" onclick="handleAiPromptOverlayClick(event)">
+            <div class="ai-prompt-card" role="dialog" aria-modal="true" aria-labelledby="ai-prompt-title" onclick="event.stopPropagation()">
+                <div class="ai-prompt-header">
+                    <h3 id="ai-prompt-title">Optional AI instruction</h3>
+                    <button class="ai-prompt-close" type="button" onclick="closeAiPrompt('cancel')" aria-label="Close">×</button>
+                </div>
+                <p class="ai-prompt-sub">Add a short instruction for this section (optional).</p>
+                <div id="ai-prompt-suggestions" class="ai-prompt-suggestions"></div>
+                <textarea id="ai-prompt-input" class="form-control" rows="3"
+                    placeholder="e.g. Use action verbs, keep bullets under 18 words"></textarea>
+                <div class="ai-prompt-actions">
+                    <button class="btn-icon" type="button" onclick="closeAiPrompt('cancel')">Cancel</button>
+                    <button class="btn-icon" type="button" onclick="skipAiPrompt()">Skip</button>
+                    <button class="btn-icon btn-primary" type="button" onclick="submitAiPrompt()">Apply</button>
+                </div>
+            </div>
+        </div>
+        <div id="ai-preview-overlay" class="ai-preview-overlay" aria-hidden="true" onclick="handleAiPreviewOverlayClick(event)">
+            <div class="ai-preview-card" role="dialog" aria-modal="true" aria-labelledby="ai-preview-title" onclick="event.stopPropagation()">
+                <div class="ai-preview-header">
+                    <h3 id="ai-preview-title">Review AI changes</h3>
+                    <button class="ai-prompt-close" type="button" onclick="closeAiPreview(false)" aria-label="Close">×</button>
+                </div>
+                <div class="ai-preview-grid">
+                    <div class="ai-preview-pane">
+                        <div class="ai-preview-label" id="ai-preview-before-label">Before</div>
+                        <pre id="ai-preview-before" class="ai-preview-content"></pre>
+                    </div>
+                    <div class="ai-preview-pane">
+                        <div class="ai-preview-label" id="ai-preview-after-label">After</div>
+                        <pre id="ai-preview-after" class="ai-preview-content"></pre>
+                    </div>
+                </div>
+                <div class="ai-prompt-actions">
+                    <button class="btn-icon" type="button" onclick="closeAiPreview(false)">Discard</button>
+                    <button class="btn-icon btn-primary" type="button" onclick="closeAiPreview(true)">Apply Changes</button>
+                </div>
             </div>
         </div>
         <div class="mobile-history-controls">


### PR DESCRIPTION
# CV Builder - AI Refinement UX + Worker Prompt Control Improvements

## Overview
This PR improves the AI enhancement/refinement flow across the CV Builder by:
- making custom prompts truly actionable,
- preserving default behavior safely when no custom instruction is provided,
- adding review/approval UX before applying AI output,
- and improving local/provider flexibility in the Cloudflare Worker.

---

## What Changed

## 1. AI Refine UX (Frontend)

### Optional Prompt Modal Improvements
- Replaced basic prompt behavior with in-app modal controls:
  - `Apply` -> uses custom prompt
  - `Skip` -> proceeds with default AI prompt
  - `Cancel` -> aborts refine action
- Added section-aware suggestion chips in the prompt modal to help users write better custom instructions quickly.

### Before/After Review Modal
- Added AI output review modal before applying changes.
- Includes side-by-side comparison:
  - `Before`
  - `After`
- Added line-level visual diff highlighting:
  - green for additions/changes
  - red for removals/changes
- Users can `Apply Changes` or `Discard`.

### Section Coverage
Refine flow + prompt modal + review modal now apply across:
- Summary
- Skills
- Experience bullets
- Project bullets
- Achievements
- Leadership
- Interests

---

## 2. Worker AI Prompt/Behavior Improvements (`index.js`)

### Provider Routing (Gemini/Grok)
- Added provider-aware text generation/refine path via `AI_PROVIDER`:
  - `grok` (default)
  - `gemini`
- `generate` and `refine-section` now route through shared text-model wrapper.

### Refine Prompt Priority
- Worker now handles prompts with explicit hierarchy:
  - Default prompt rules always apply when custom prompt is empty.
  - Custom prompt is treated as highest-priority instruction when provided.

### Bullet Count Handling (Critical Fix)
- Default refine behavior preserves bullet count.
- If user explicitly requests count change (e.g. "make 4 bullets", "stretch to 7-8 points"), worker now detects and honors it.
- Added range-aware parsing for count instructions (`7-8`, `7 to 8`).
- Enforcement logic aligns output to requested exact/range target where applicable.

### AI Enhance Safety (Work Experience)
- Updated generation + enforcement logic to avoid unintended work-experience bullet reduction.
- Preserves user-entered role coverage and bullet continuity more safely.

---

## 3. Files Updated

- `cv-builder/index.js`
- `cv-builder/cv-script.js`
- `cv-builder/index.html`
- `cv-builder/cv-styles.css`

---

## Behavior Summary (User Impact)

- Users can now refine with confidence using:
  - guided prompt chips,
  - default prompt fallback via `Skip`,
  - preview and explicit approval before apply.
- AI now better respects custom instructions.
- Work experience bullet drop issues are significantly reduced.

---

## Cloudflare Worker Config Notes

Ensure worker env contains:
- `AI_PROVIDER` (`grok` for production)
- `GROK_API_KEY`
- `GEMINI_API_KEY` (still used for convert flow and provider flexibility)

---

## QA Checklist

- [ ] Prompt modal shows `Apply`, `Skip`, `Cancel` behavior correctly
- [ ] Suggestion chips populate by section and append text
- [ ] Review modal opens before apply for all supported sections
- [ ] Diff highlight renders correctly on desktop + mobile
- [ ] Default refine preserves bullet count when no count-change instruction is given
- [ ] Explicit count prompts (e.g. `4`, `7-8`) are honored
- [ ] AI enhance no longer unintentionally drops experience bullets
- [ ] Worker env validation returns clear errors when keys/provider missing