### PR TITLE
Refactor CV rendering logic to improve title merging display 

### DIFF
--- a/cv-builder/classic-refined.html
+++ b/cv-builder/classic-refined.html
@@ -284,7 +284,7 @@
                         <span data-field="dates"></span>
                     </div>
                     <div class="details-grid" style="grid-template-columns: 140px 1fr; border-top: none;">
-                        <div class="details-label">Key Areas of Exposure:</div>
+                        <div class="details-label" data-field="category"></div>
                         <div class="details-content">
                             <ul data-list="bullets"></ul>
                         </div>

--- a/cv-builder/cv-common.js
+++ b/cv-builder/cv-common.js
@@ -185,11 +185,19 @@ function renderCV(data) {
         setHTMLIn(block, '[data-field="company"]', item.company);
         setHTMLIn(block, '[data-field="dates"]', item.dates);
         setHTMLIn(block, '[data-field="category"]', item.category); // Department/Area like "Business Finance"
+        applyExperienceTitleMergeDisplayV2(block, item);
 
         const roleEl = block.querySelector('[data-field="role"]');
         if (roleEl) roleEl.style.display = stripTags(item.role || '').trim() ? '' : 'none';
         const categoryEl = block.querySelector('[data-field="category"]');
         if (categoryEl) categoryEl.style.display = stripTags(item.category || '').trim() ? '' : 'none';
+        if (item.titleMergedWithPrevious) {
+            if (roleEl) roleEl.style.display = 'none';
+            const companyEl = block.querySelector('[data-field="company"]');
+            const datesEl = block.querySelector('[data-field="dates"]');
+            if (companyEl) companyEl.style.display = 'none';
+            if (datesEl) datesEl.style.display = 'none';
+        }
 
         const ul = block.querySelector('[data-list="bullets"]');
         if (ul) {
@@ -740,7 +748,12 @@ function buildRenderedExperience(items) {
 
     return groups.map(group => {
         const primary = group[0] || {};
-        if (group.length === 1) return primary;
+        if (group.length === 1) {
+            return {
+                ...primary,
+                titleMergedWithPrevious: !!primary.titleMergedWithPrevious
+            };
+        }
 
         const companyLines = group.map(item => {
             const company = item.company || '';
@@ -773,8 +786,105 @@ function buildRenderedExperience(items) {
             company: companyLines.join('<br>'),
             dates: dateLines.join('<br>'),
             category: mergedCategoryHTML,
-            bullets: mergedBullets
+            bullets: mergedBullets,
+            titleMergedWithPrevious: false
         };
+    });
+}
+
+function applyExperienceTitleMergeDisplay(block, item) {
+    if (!block) return;
+    const hideTitle = !!item?.titleMergedWithPrevious;
+    block.classList.toggle('experience-title-merged', hideTitle);
+
+    const titleFields = [
+        block.querySelector('[data-field="role"]'),
+        block.querySelector('[data-field="company"]'),
+        block.querySelector('[data-field="dates"]')
+    ].filter(Boolean);
+
+    titleFields.forEach(el => {
+        el.style.display = hideTitle ? 'none' : '';
+    });
+
+    const wrapperSelectors = [
+        '.work-exp-header',
+        '.sub-header',
+        '.sub-header-title',
+        '.sub-header-date',
+        '.item-main-title',
+        '.item-date',
+        '.exp-title',
+        '.job-header',
+        '.job-header-row',
+        '.entry-header'
+    ];
+
+    wrapperSelectors.forEach(selector => {
+        block.querySelectorAll(selector).forEach(el => {
+            if (!hideTitle) {
+                el.style.display = '';
+                return;
+            }
+            const text = (el.textContent || '').replace(/[\s\|\-–—:\[\]\(\)]/g, '');
+            el.style.display = text ? '' : 'none';
+        });
+    });
+}
+
+function applyExperienceTitleMergeDisplayV2(block, item) {
+    if (!block) return;
+    const hideTitle = !!item?.titleMergedWithPrevious;
+    block.classList.toggle('experience-title-merged', hideTitle);
+
+    const titleFields = ['role', 'company', 'dates']
+        .map(field => block.querySelector(`[data-field="${field}"]`))
+        .filter(Boolean);
+    const wrappersToToggle = new Set();
+
+    const addWrapper = (el) => {
+        if (el && el !== block) wrappersToToggle.add(el);
+    };
+
+    titleFields.forEach(el => {
+        el.style.display = hideTitle ? 'none' : '';
+        addWrapper(el.closest('.work-exp-header'));
+        addWrapper(el.closest('.work-exp-row'));
+        addWrapper(el.closest('.sub-header'));
+        addWrapper(el.closest('.sub-header-title'));
+        addWrapper(el.closest('.sub-header-date'));
+        addWrapper(el.closest('.item-main-title'));
+        addWrapper(el.closest('.item-date'));
+        addWrapper(el.closest('.exp-title'));
+        addWrapper(el.closest('.sub-header-cell'));
+        addWrapper(el.closest('.job-title-row'));
+        addWrapper(el.closest('.job-header'));
+        addWrapper(el.closest('.exp-header-details'));
+        addWrapper(el.closest('.work-subheader'));
+        addWrapper(el.closest('.work-box-header'));
+        addWrapper(el.closest('.work-box-header-row'));
+    });
+
+    wrappersToToggle.forEach(el => {
+        el.style.display = hideTitle ? 'none' : '';
+        const row = el.closest('tr');
+        if (row && row !== block && row.querySelector('.sub-header-cell')) {
+            row.style.display = hideTitle ? 'none' : '';
+        }
+    });
+
+    block.querySelectorAll('.work-exp-content > div:first-child, .details-grid, .work-box-header + .work-table').forEach(el => {
+        if (el.matches('.details-grid')) {
+            el.style.borderTop = hideTitle ? 'none' : '';
+            return;
+        }
+        if (el.matches('.work-box-header + .work-table')) {
+            el.style.marginTop = hideTitle ? '0' : '';
+            return;
+        }
+        if (!(el.textContent || '').trim()) {
+            el.style.display = hideTitle ? 'none' : '';
+        }
     });
 }
 

--- a/cv-builder/cv-script.js
+++ b/cv-builder/cv-script.js
@@ -612,7 +612,12 @@
 
         function normalizeImportedString(value) {
             if (value === null || value === undefined) return '';
-            return String(value).trim();
+            const tmp = document.createElement('div');
+            tmp.innerHTML = convertMarkdownBoldToHTML(String(value));
+            return (tmp.textContent || '')
+                .replace(/\u00a0/g, ' ')
+                .replace(/\s+/g, ' ')
+                .trim();
         }
 
         function htmlToMultilineText(value) {
@@ -812,29 +817,30 @@
 
             if (Array.isArray(incoming.education)) {
                 normalized.education = incoming.education.map(item => ({
-                    degree: normalizeImportedRichText(item?.degree || '', 'education'),
-                    institute: normalizeImportedRichText(item?.institute || item?.institution || '', 'education'),
+                    degree: normalizeImportedString(item?.degree || ''),
+                    institute: normalizeImportedString(item?.institute || item?.institution || ''),
                     year: normalizeImportedString(item?.year || ''),
-                    marks: normalizeImportedRichText(item?.marks || '', 'education'),
-                    remarks: normalizeImportedRichText(item?.remarks || '', 'education')
+                    marks: normalizeImportedString(item?.marks || ''),
+                    remarks: normalizeImportedString(item?.remarks || '')
                 })).filter(item => Object.values(item).some(v => normalizeImportedString(getPlainTextFromHTML(v))));
             }
 
             if (Array.isArray(incoming.experience)) {
                 normalized.experience = incoming.experience.map((item, index) => ({
-                    role: normalizeImportedRichText(item?.role || '', 'experience'),
-                    company: normalizeImportedRichText(item?.company || '', 'experience'),
-                    dates: normalizeImportedRichText(item?.dates || '', 'experience'),
-                    category: normalizeImportedRichText(item?.category || '', 'experience'),
+                    role: normalizeImportedString(item?.role || ''),
+                    company: normalizeImportedString(item?.company || ''),
+                    dates: normalizeImportedString(item?.dates || ''),
+                    category: normalizeCategoryHTML(htmlToMultilineText(item?.category || '')),
                     bullets: applyBoldToBulletList(item?.bullets || [], 'experience'),
-                    mergedWithPrevious: !!item?.mergedWithPrevious && index > 0
+                    mergedWithPrevious: !!item?.mergedWithPrevious && index > 0,
+                    titleMergedWithPrevious: !!item?.titleMergedWithPrevious && index > 0 && !item?.mergedWithPrevious
                 })).filter(item => Object.values(item).some(v => Array.isArray(v) ? v.length : normalizeImportedString(getPlainTextFromHTML(v))));
             }
 
             if (Array.isArray(incoming.projects)) {
                 normalized.projects = incoming.projects.map(item => ({
-                    title: normalizeImportedRichText(item?.title || '', 'projects'),
-                    description: normalizeImportedRichText(item?.description || '', 'projects'),
+                    title: normalizeImportedString(item?.title || ''),
+                    description: normalizeImportedString(item?.description || ''),
                     bullets: applyBoldToBulletList(item?.bullets || [], 'projects')
                 })).filter(item => Object.values(item).some(v => Array.isArray(v) ? v.length : normalizeImportedString(getPlainTextFromHTML(v))));
             }
@@ -842,11 +848,11 @@
             if (Array.isArray(incoming.certifications)) {
                 normalized.certifications = incoming.certifications.map(item => {
                     if (typeof item === 'string') {
-                        return { name: normalizeImportedRichText(item, 'certifications'), issuer: '' };
+                        return { name: normalizeImportedString(item), issuer: '' };
                     }
                     return {
-                        name: normalizeImportedRichText(item?.name || '', 'certifications'),
-                        issuer: normalizeImportedRichText(item?.issuer || '', 'certifications')
+                        name: normalizeImportedString(item?.name || ''),
+                        issuer: normalizeImportedString(item?.issuer || '')
                     };
                 }).filter(item => normalizeImportedString(getPlainTextFromHTML(item.name || item.issuer)));
             }
@@ -990,6 +996,7 @@
                 if (!exp || typeof exp !== 'object') cvData.experience[index] = {};
                 if (!Array.isArray(cvData.experience[index].bullets)) cvData.experience[index].bullets = [];
                 cvData.experience[index].mergedWithPrevious = !!cvData.experience[index].mergedWithPrevious && index > 0;
+                cvData.experience[index].titleMergedWithPrevious = !!cvData.experience[index].titleMergedWithPrevious && index > 0 && !cvData.experience[index].mergedWithPrevious;
             });
         }
 
@@ -1086,6 +1093,63 @@
             if (typeof cvData.summary !== 'string') cvData.summary = cvData.summary ? String(cvData.summary) : '';
             if (typeof cvData.skills !== 'string') cvData.skills = cvData.skills ? String(cvData.skills) : '';
             if (typeof cvData.themeAccent !== 'string') cvData.themeAccent = '';
+            cvData.personal.name = normalizeImportedString(cvData.personal.name || '');
+            cvData.personal.tagline = normalizeImportedString(cvData.personal.tagline || '');
+            cvData.personal.contact = normalizeImportedString(cvData.personal.contact || '');
+            cvData.personal.phone = normalizeImportedString(cvData.personal.phone || '');
+            cvData.personal.email = normalizeImportedString(cvData.personal.email || '');
+            cvData.personal.linkedin = normalizeImportedString(cvData.personal.linkedin || '');
+            cvData.personal.location = normalizeImportedString(cvData.personal.location || '');
+            cvData.education = cvData.education.map(item => {
+                const entry = item && typeof item === 'object' ? item : {};
+                return {
+                    ...entry,
+                    degree: normalizeImportedString(entry.degree || ''),
+                    institute: normalizeImportedString(entry.institute || entry.institution || ''),
+                    year: normalizeImportedString(entry.year || ''),
+                    marks: normalizeImportedString(entry.marks || ''),
+                    remarks: normalizeImportedString(entry.remarks || '')
+                };
+            });
+            cvData.experience = cvData.experience.map((item, index) => {
+                const entry = item && typeof item === 'object' ? item : {};
+                return {
+                    ...entry,
+                    role: normalizeImportedString(entry.role || ''),
+                    company: normalizeImportedString(entry.company || ''),
+                    dates: normalizeImportedString(entry.dates || ''),
+                    category: normalizeCategoryHTML(htmlToMultilineText(entry.category || '')),
+                    mergedWithPrevious: !!entry.mergedWithPrevious && index > 0,
+                    titleMergedWithPrevious: !!entry.titleMergedWithPrevious && index > 0 && !entry.mergedWithPrevious,
+                    bullets: Array.isArray(entry.bullets) ? entry.bullets : []
+                };
+            });
+            cvData.projects = cvData.projects.map(item => {
+                const entry = item && typeof item === 'object' ? item : {};
+                return {
+                    ...entry,
+                    title: normalizeImportedString(entry.title || ''),
+                    description: normalizeImportedString(entry.description || ''),
+                    bullets: Array.isArray(entry.bullets) ? entry.bullets : []
+                };
+            });
+            cvData.certifications = cvData.certifications.map(item => {
+                const entry = item && typeof item === 'object' ? item : {};
+                return {
+                    ...entry,
+                    name: normalizeImportedString(entry.name || (typeof item === 'string' ? item : '')),
+                    issuer: normalizeImportedString(entry.issuer || '')
+                };
+            });
+            cvData.customSections = cvData.customSections.map(section => {
+                const entry = section && typeof section === 'object' ? section : {};
+                return {
+                    ...entry,
+                    id: normalizeImportedString(entry.id || ''),
+                    title: normalizeImportedString(entry.title || 'Custom Section'),
+                    items: Array.isArray(entry.items) ? entry.items : []
+                };
+            });
             ensureTableSettingsShape();
         }
 
@@ -1495,7 +1559,9 @@
                 const div = document.createElement('div');
                 div.className = 'list-item';
                 const isMergedChild = !!exp.mergedWithPrevious;
+                const isTitleMergedChild = !!exp.titleMergedWithPrevious && !isMergedChild;
                 const canMergeWithPrevious = index > 0 && !isMergedChild;
+                const canTitleMergeWithPrevious = index > 0 && !isMergedChild;
                 const mergeAction = isMergedChild
                     ? `unmergeExp(${index})`
                     : `mergeExpWithPrevious(${index})`;
@@ -1504,14 +1570,24 @@
                     : (canMergeWithPrevious ? 'Merge with previous stint' : 'First stint cannot merge backward');
                 const mergeStyle = !isMergedChild && !canMergeWithPrevious ? 'opacity:.35;pointer-events:none;' : '';
                 const mergeLabel = isMergedChild ? 'Unmerge' : 'Merge';
+                const titleMergeAction = isTitleMergedChild
+                    ? `unmergeExpTitle(${index})`
+                    : `mergeExpTitleWithPrevious(${index})`;
+                const titleMergeTitle = isTitleMergedChild
+                    ? 'Show this title again'
+                    : (canTitleMergeWithPrevious ? 'Reuse the previous title but keep a separate subsection' : 'First stint cannot title-merge backward');
+                const titleMergeStyle = !isTitleMergedChild && !canTitleMergeWithPrevious ? 'opacity:.35;pointer-events:none;' : '';
+                const titleMergeLabel = isTitleMergedChild ? 'Show Title' : 'Title Merge';
                 div.innerHTML = `
                     <div class="item-actions">
                         <div class="action-btn" onclick="moveExp(${index}, -1)">&#9650;</div>
                         <div class="action-btn" onclick="moveExp(${index}, 1)">&#9660;</div>
                         <div class="action-btn merge-toggle ${isMergedChild ? 'active' : ''}" onclick="${mergeAction}" title="${mergeTitle}" style="${mergeStyle}">${mergeLabel}</div>
+                        <div class="action-btn merge-toggle ${isTitleMergedChild ? 'active' : ''}" onclick="${titleMergeAction}" title="${titleMergeTitle}" style="${titleMergeStyle}">${titleMergeLabel}</div>
                         <div class="action-btn delete" onclick="removeExp(${index})">&times;</div>
                     </div>
                     ${isMergedChild ? `<div style="margin-bottom:8px; padding:8px 10px; border:1px solid #dbeafe; background:#eff6ff; border-radius:12px; color:#1d4ed8; font-size:12px;">This stint is merged with the experience above in preview and PDF.</div>` : ''}
+                    ${isTitleMergedChild ? `<div style="margin-bottom:8px; padding:8px 10px; border:1px solid #d1fae5; background:#ecfdf5; border-radius:12px; color:#047857; font-size:12px;">This subsection reuses the title above in preview and PDF, but keeps its own category and bullets.</div>` : ''}
                     <div class="form-group">
                         <label>Role</label>
                         <input class="form-control" value="${exp.role || ''}" oninput="updateExp(${index}, 'role', this.value)" placeholder="e.g. Articled Assistant">
@@ -1649,6 +1725,14 @@
                 cvData.experience[index].category = normalizeCategoryHTML(value);
             } else if (field === 'mergedWithPrevious') {
                 cvData.experience[index].mergedWithPrevious = !!value && index > 0;
+                if (cvData.experience[index].mergedWithPrevious) {
+                    cvData.experience[index].titleMergedWithPrevious = false;
+                }
+            } else if (field === 'titleMergedWithPrevious') {
+                cvData.experience[index].titleMergedWithPrevious = !!value && index > 0;
+                if (cvData.experience[index].titleMergedWithPrevious) {
+                    cvData.experience[index].mergedWithPrevious = false;
+                }
             } else {
                 cvData.experience[index][field] = value;
             }
@@ -1693,7 +1777,7 @@
         }
 
         function addExperience() {
-            cvData.experience.push({ role: "", company: "", dates: "", category: "", bullets: [], mergedWithPrevious: false });
+            cvData.experience.push({ role: "", company: "", dates: "", category: "", bullets: [], mergedWithPrevious: false, titleMergedWithPrevious: false });
             normalizeExperienceMerges();
             renderExpInputs();
             postToFrame();
@@ -1710,6 +1794,7 @@
         function mergeExpWithPrevious(i) {
             if (i <= 0 || !cvData.experience[i]) return;
             cvData.experience[i].mergedWithPrevious = true;
+            cvData.experience[i].titleMergedWithPrevious = false;
             normalizeExperienceMerges();
             renderExpInputs();
             postToFrame();
@@ -1717,6 +1802,21 @@
         function unmergeExp(i) {
             if (i <= 0 || !cvData.experience[i]) return;
             cvData.experience[i].mergedWithPrevious = false;
+            normalizeExperienceMerges();
+            renderExpInputs();
+            postToFrame();
+        }
+        function mergeExpTitleWithPrevious(i) {
+            if (i <= 0 || !cvData.experience[i]) return;
+            cvData.experience[i].titleMergedWithPrevious = true;
+            cvData.experience[i].mergedWithPrevious = false;
+            normalizeExperienceMerges();
+            renderExpInputs();
+            postToFrame();
+        }
+        function unmergeExpTitle(i) {
+            if (i <= 0 || !cvData.experience[i]) return;
+            cvData.experience[i].titleMergedWithPrevious = false;
             normalizeExperienceMerges();
             renderExpInputs();
             postToFrame();
@@ -3400,7 +3500,7 @@ async function downloadCvFile(format = 'pdf') {
                 id: Date.now(),
                 at: new Date().toISOString(),
                 source,
-                title: cvData.personal.name || 'Untitled CV',
+                title: normalizeImportedString(cvData.personal.name || '') || 'Untitled CV',
                 data: JSON.parse(JSON.stringify(cvData))
             };
             history.unshift(snapshot);
@@ -3424,7 +3524,7 @@ async function downloadCvFile(format = 'pdf') {
                 const d = new Date(s.at);
                 const label = d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }) +
                     ' · ' + d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
-                const safeTitle = (s.title || 'Untitled CV')
+                const safeTitle = (normalizeImportedString(s.title || '') || 'Untitled CV')
                     .replace(/&/g, '&amp;')
                     .replace(/</g, '&lt;')
                     .replace(/>/g, '&gt;');


### PR DESCRIPTION
# Fix imported HTML leakage and add title-merge support for experience sections

## Summary
This PR improves CV import cleanup and experience rendering in the CV builder.

It fixes imported formatting tags like `<strong>` appearing in plain text fields, adds a new `Title Merge` mode for experience entries, and tightens template-specific rendering so merged subsections don’t leave duplicate headings, separators, or spacing artifacts.

## What Changed
- Sanitized imported plain-text fields so HTML tags are stripped before populating editor inputs and version titles.
- Kept rich formatting only where it belongs, like summary, skills, and bullet content.
- Added a new `Title Merge` option for experience entries.
- Preserved the existing `Merge` behavior for fully combining entries into one block.
- Made `Merge` and `Title Merge` mutually exclusive.
- Updated experience rendering so title-merged rows reuse the previous heading while keeping separate category and bullet sections.
- Fixed blank separators and spacing gaps caused by hidden repeated titles across multiple templates.
- Fixed `classic-refined` so the left experience column now uses the actual category value instead of the hardcoded `Key Areas of Exposure:` label.
- Added cleanup in data normalization so older imported/local-saved CV data also gets repaired on reload.

## Experience Merge Behavior
### `Merge`
- Combines adjacent experience entries into a single flattened rendered block.

### `Title Merge`
- Reuses the previous title/company/date heading.
- Keeps the current row’s category and bullets as a separate subsection.

Example:
- `Sultania Sujit & Co., Kolkata - Article Assistant`
- `Statutory Audit & Tax Audit` with bullets
- `Bank Audit` with bullets
- `Direct Tax` with bullets

Instead of repeating the same title three times.

## Files Changed
- `cv-builder/cv-script.js`
- `cv-builder/cv-common.js`
- `cv-builder/classic-refined.html`

## Testing
Please verify manually:
1. Import a CV containing bold/HTML-formatted content and confirm plain editor fields do not show raw tags.
2. Create multiple experience rows with the same company/role and use `Title Merge`.
3. Confirm the first row keeps the heading and later rows show only subsection content.
4. Check the affected templates for missing duplicate separators, blank header gaps, or incorrect left-column labels.