### PR TITLE
feat: add professional blue banner CV template and supporting JS logic

### DIFF
--- a/cv-builder/blue-banner-professional.html
+++ b/cv-builder/blue-banner-professional.html
@@ -278,13 +278,13 @@
 
             <!-- CAREER OBJECTIVE -->
             <div class="sortable-section" data-section-id="summary">
-                <div class="section-banner">Career Objective</div>
+                <div class="section-header">Career Objective</div>
                 <div class="tagline-summary" data-field="summary"></div>
             </div>
 
             <!-- EDUCATION -->
             <div class="sortable-section" data-section-id="education">
-                <div class="section-banner">Education</div>
+                <div class="section-header">Education</div>
                 <div id="education-list">
                     <!-- template row — cloned by cv-common.js for each entry -->
                     <div class="template" style="display:none;">
@@ -301,7 +301,7 @@
 
             <!-- EXPERIENCE -->
             <div class="sortable-section" data-section-id="experience">
-                <div class="section-banner">Work Experience</div>
+                <div class="section-header">Work Experience</div>
                 <div id="experience-list">
                     <div class="template" style="display:none;">
                         <div class="item-row work-exp-row">
@@ -319,7 +319,7 @@
 
             <!-- PROJECTS -->
             <div class="sortable-section" data-section-id="projects">
-                <div class="section-banner">Projects</div>
+                <div class="section-header">Projects</div>
                 <div id="projects-list">
                     <div class="template" style="display:none;">
                         <div class="item-row">
@@ -335,31 +335,31 @@
 
             <!-- CERTIFICATIONS -->
             <div class="sortable-section" data-section-id="certifications">
-                <div class="section-banner">Certifications</div>
+                <div class="section-header">Certifications</div>
                 <ul data-list="certifications"></ul>
             </div>
 
             <!-- ACHIEVEMENTS -->
             <div class="sortable-section" data-section-id="achievements">
-                <div class="section-banner">Achievements &amp; Awards</div>
+                <div class="section-header">Achievements &amp; Awards</div>
                 <ul data-list="achievements"></ul>
             </div>
 
             <!-- LEADERSHIP -->
             <div class="sortable-section" data-section-id="leadership">
-                <div class="section-banner">Leadership</div>
+                <div class="section-header">Leadership</div>
                 <ul data-list="leadership"></ul>
             </div>
 
             <!-- INTERESTS -->
             <div class="sortable-section" data-section-id="interests">
-                <div class="section-banner">Interests &amp; Hobbies</div>
+                <div class="section-header">Interests &amp; Hobbies</div>
                 <ul data-list="interests"></ul>
             </div>
 
             <!-- SKILLS -->
             <div class="sortable-section" data-section-id="skills">
-                <div class="section-banner">Skills</div>
+                <div class="section-header">Skills</div>
                 <div data-field="skills"></div>
             </div>
 

--- a/cv-builder/blue-banner-professional.html
+++ b/cv-builder/blue-banner-professional.html
@@ -1,0 +1,433 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <title>My CV</title>
+    <style>
+        :root {
+            --blue-header: #155f82;
+            --light-blue-bg: #dbe8f8;
+            --text-black: #000000;
+            --bg-white: #ffffff;
+            --font-main: 'Calibri', 'Arial', sans-serif;
+            --viewer-bg: #525659;
+            --ref-width: 1000px;
+            --ref-height: 1414px;
+            --content-scale: 1;
+        }
+
+        html {
+            -webkit-text-size-adjust: 100%;
+            text-size-adjust: 100%;
+        }
+
+        * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+            -webkit-print-color-adjust: exact;
+            print-color-adjust: exact;
+        }
+
+        body {
+            background-color: var(--viewer-bg);
+            font-family: var(--font-main);
+            overflow-x: hidden;
+            min-height: 100vh;
+            width: 100vw;
+            margin: 0;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+
+        #zoom-wrapper {
+            width: 100%;
+            overflow: hidden;
+            display: flex;
+            justify-content: center;
+            padding-top: 20px;
+            padding-bottom: 20px;
+        }
+
+        .resume-container {
+            width: var(--ref-width);
+            height: var(--ref-height);
+            background: var(--bg-white);
+            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
+            position: relative;
+            padding: calc(24px * var(--content-scale)) calc(22px * var(--content-scale));
+            display: flex;
+            flex-direction: column;
+            flex-shrink: 0;
+            transform-origin: top center;
+            font-size: calc(15.5px * var(--content-scale));
+            color: var(--text-black);
+            line-height: 1.25;
+        }
+
+        /* ── Header ── */
+        header {
+            text-align: left;
+            margin-bottom: calc(6px * var(--content-scale));
+        }
+
+        h1 {
+            font-size: calc(22px * var(--content-scale));
+            font-weight: bold;
+            margin-bottom: calc(2px * var(--content-scale));
+        }
+
+        h1:empty {
+            display: none;
+        }
+
+        .header-tagline {
+            font-weight: bold;
+            font-size: calc(13px * var(--content-scale));
+            margin-bottom: calc(3px * var(--content-scale));
+            color: #333;
+        }
+
+        .header-tagline:empty {
+            display: none;
+        }
+
+        .contact-info {
+            display: block;
+            text-align: left;
+            margin-bottom: calc(4px * var(--content-scale));
+            font-weight: bold;
+            font-size: calc(13.5px * var(--content-scale));
+        }
+
+        .contact-info a,
+        .contact-info [data-field] a {
+            color: #0000ff;
+            text-decoration: underline;
+            font-weight: bold;
+        }
+
+        /* ── Section banners (static + cv-common.js-injected custom sections) ── */
+        .section-banner,
+        .section-header,
+        .section-header-2,
+        .section-title {
+            background-color: var(--blue-header);
+            color: white;
+            padding: calc(3px * var(--content-scale)) calc(6px * var(--content-scale));
+            font-weight: bold;
+            text-transform: uppercase;
+            text-align: left;
+            margin-top: calc(6px * var(--content-scale));
+            margin-bottom: calc(4px * var(--content-scale));
+            letter-spacing: 0.5px;
+            font-size: 1em;
+        }
+
+        /* ── Item rows (education / experience) ── */
+        .item-row {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-start;
+            background-color: var(--light-blue-bg);
+            padding: calc(2px * var(--content-scale)) calc(6px * var(--content-scale));
+            margin-top: calc(3px * var(--content-scale));
+            margin-bottom: calc(1px * var(--content-scale));
+        }
+
+        .item-left {
+            flex: 1;
+            min-width: 0;
+        }
+
+        .item-title {
+            font-weight: bold;
+            text-align: left;
+        }
+
+        .item-date {
+            font-style: italic;
+            font-weight: normal;
+            text-align: right;
+            white-space: nowrap;
+            padding-left: calc(8px * var(--content-scale));
+            flex-shrink: 0;
+        }
+
+        /* institution shown inline after degree with | separator */
+        .edu-inst-inline:not(:empty)::before {
+            content: " | ";
+        }
+
+        /* company shown inline after role with | separator */
+        .exp-company-inline:not(:empty)::before {
+            content: " | ";
+        }
+
+        /* ── Subtext (remarks, description) ── */
+        .edu-subtext {
+            margin-left: calc(8px * var(--content-scale));
+            margin-top: calc(1px * var(--content-scale));
+            margin-bottom: calc(2px * var(--content-scale));
+            line-height: 1.25;
+            color: #222;
+        }
+
+        .edu-subtext:empty {
+            display: none;
+        }
+
+        /* ── Sub-section titles (experience category) ── */
+        .sub-section-title {
+            font-weight: bold;
+            margin-top: calc(4px * var(--content-scale));
+            margin-bottom: calc(2px * var(--content-scale));
+            background-color: var(--light-blue-bg);
+            color: var(--text-black);
+            padding: calc(2px * var(--content-scale)) calc(6px * var(--content-scale));
+            display: block;
+        }
+
+        .sub-section-title:empty {
+            display: none;
+        }
+
+        /* ── Lists ── */
+        ul {
+            list-style-type: disc;
+            margin-left: calc(20px * var(--content-scale));
+            margin-bottom: calc(3px * var(--content-scale));
+            margin-top: calc(2px * var(--content-scale));
+        }
+
+        li {
+            margin-bottom: calc(1.5px * var(--content-scale));
+            text-align: justify;
+            line-height: 1.25;
+        }
+
+        li:last-child {
+            margin-bottom: 0;
+        }
+
+        /* Skills output from cv-common.js renderSkillsContent */
+        [data-field="skills"] ul,
+        [data-field="skills"] .cv-skills-list {
+            margin-left: calc(20px * var(--content-scale));
+        }
+
+        /* ── Summary / Career Objective ── */
+        .tagline-summary {
+            line-height: 1.35;
+            text-align: justify;
+            margin-bottom: calc(4px * var(--content-scale));
+        }
+
+        /* ── Print ── */
+        @media print {
+            @page {
+                size: A4 portrait;
+                margin: 0;
+            }
+
+            html,
+            body {
+                width: 210mm;
+                height: 297mm;
+                margin: 0 !important;
+                padding: 0 !important;
+                overflow: hidden !important;
+                background: #ffffff !important;
+            }
+
+            #zoom-wrapper {
+                display: block !important;
+                width: 100% !important;
+                height: auto !important;
+                margin: 0 !important;
+                padding: 0 !important;
+                overflow: visible !important;
+            }
+
+            .resume-container {
+                width: 1000px !important;
+                margin: 0 auto !important;
+                box-shadow: none !important;
+                border: none !important;
+                zoom: 0.7937;
+                transform-origin: top center;
+                position: static !important;
+            }
+        }
+    </style>
+</head>
+
+<body>
+    <div id="zoom-wrapper">
+        <div class="resume-container" id="cv-page">
+
+            <!-- HEADER — not a sortable section, always at top -->
+            <header>
+                <h1 data-field="name"></h1>
+                <div class="header-tagline" data-field="tagline"></div>
+                <div class="contact-info contact-block" data-field="contact"></div>
+            </header>
+
+            <!-- CAREER OBJECTIVE -->
+            <div class="sortable-section" data-section-id="summary">
+                <div class="section-banner">Career Objective</div>
+                <div class="tagline-summary" data-field="summary"></div>
+            </div>
+
+            <!-- EDUCATION -->
+            <div class="sortable-section" data-section-id="education">
+                <div class="section-banner">Education</div>
+                <div id="education-list">
+                    <!-- template row — cloned by cv-common.js for each entry -->
+                    <div class="template" style="display:none;">
+                        <div class="item-row">
+                            <div class="item-title item-left">
+                                <span data-field="degree"></span><span class="edu-inst-inline" data-field="institution"></span>
+                            </div>
+                            <span class="item-date" data-field="year"></span>
+                        </div>
+                        <div class="edu-subtext" data-field="remarks"></div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- EXPERIENCE -->
+            <div class="sortable-section" data-section-id="experience">
+                <div class="section-banner">Work Experience</div>
+                <div id="experience-list">
+                    <div class="template" style="display:none;">
+                        <div class="item-row work-exp-row">
+                            <div class="item-title item-left">
+                                <span data-field="role"></span><span class="exp-company-inline" data-field="company"></span>
+                            </div>
+                            <span class="item-date" data-field="dates"></span>
+                        </div>
+                        <!-- category shown as sub-header when present (hidden by cv-common.js when empty) -->
+                        <div class="sub-section-title" data-field="category"></div>
+                        <ul data-list="bullets"></ul>
+                    </div>
+                </div>
+            </div>
+
+            <!-- PROJECTS -->
+            <div class="sortable-section" data-section-id="projects">
+                <div class="section-banner">Projects</div>
+                <div id="projects-list">
+                    <div class="template" style="display:none;">
+                        <div class="item-row">
+                            <div class="item-left">
+                                <div class="item-title" data-field="title"></div>
+                                <div class="exp-company-line" data-field="description"></div>
+                            </div>
+                        </div>
+                        <ul data-list="bullets"></ul>
+                    </div>
+                </div>
+            </div>
+
+            <!-- CERTIFICATIONS -->
+            <div class="sortable-section" data-section-id="certifications">
+                <div class="section-banner">Certifications</div>
+                <ul data-list="certifications"></ul>
+            </div>
+
+            <!-- ACHIEVEMENTS -->
+            <div class="sortable-section" data-section-id="achievements">
+                <div class="section-banner">Achievements &amp; Awards</div>
+                <ul data-list="achievements"></ul>
+            </div>
+
+            <!-- LEADERSHIP -->
+            <div class="sortable-section" data-section-id="leadership">
+                <div class="section-banner">Leadership</div>
+                <ul data-list="leadership"></ul>
+            </div>
+
+            <!-- INTERESTS -->
+            <div class="sortable-section" data-section-id="interests">
+                <div class="section-banner">Interests &amp; Hobbies</div>
+                <ul data-list="interests"></ul>
+            </div>
+
+            <!-- SKILLS -->
+            <div class="sortable-section" data-section-id="skills">
+                <div class="section-banner">Skills</div>
+                <div data-field="skills"></div>
+            </div>
+
+        </div>
+    </div>
+
+    <!-- cv-common.js handles all postMessage rendering and section ordering -->
+    <script src="cv-common.js"></script>
+    <script>
+        function scaleToFit() {
+            const page = document.getElementById('cv-page');
+            const targetWidth = window.innerWidth - 20;
+            const scale = targetWidth < 1000 ? targetWidth / 1000 : 1;
+            page.style.transform = `scale(${scale})`;
+            const spaceToRemove = 1414 - (1414 * scale);
+            page.style.marginBottom = `-${spaceToRemove}px`;
+        }
+
+        function shrinkContentToFit() {
+            const page = document.getElementById('cv-page');
+            let contentScale = 1.0;
+            document.documentElement.style.setProperty('--content-scale', contentScale);
+            let i = 0;
+            while (page.scrollHeight > 1414 && i < 60) {
+                contentScale -= 0.01;
+                document.documentElement.style.setProperty('--content-scale', contentScale);
+                i++;
+            }
+        }
+
+        let _screenTransform = '';
+        let _screenMarginBottom = '';
+
+        function enablePrintMode() {
+            const page = document.getElementById('cv-page');
+            _screenTransform = page.style.transform;
+            _screenMarginBottom = page.style.marginBottom;
+            page.style.transform = 'scale(1)';
+            page.style.marginBottom = '0px';
+            shrinkContentToFit();
+        }
+
+        function disablePrintMode() {
+            const page = document.getElementById('cv-page');
+            page.style.transform = _screenTransform || '';
+            page.style.marginBottom = _screenMarginBottom || '';
+            scaleToFit();
+        }
+
+        window.addEventListener('load', function () {
+            shrinkContentToFit();
+            scaleToFit();
+            const mq = window.matchMedia('print');
+            if (mq.addEventListener) {
+                mq.addEventListener('change', e => e.matches ? enablePrintMode() : disablePrintMode());
+            } else if (mq.addListener) {
+                mq.addListener(e => e.matches ? enablePrintMode() : disablePrintMode());
+            }
+            window.addEventListener('beforeprint', enablePrintMode);
+            window.addEventListener('afterprint', disablePrintMode);
+        });
+
+        let _resizeTimer;
+        window.addEventListener('resize', function () {
+            clearTimeout(_resizeTimer);
+            _resizeTimer = setTimeout(scaleToFit, 100);
+        });
+    </script>
+</body>
+
+</html>

--- a/cv-builder/cv-script.js
+++ b/cv-builder/cv-script.js
@@ -2300,7 +2300,8 @@
             { file: 'navy-merit.html', name: 'Navy Merit', accent: '#0f2f63', style: 'merit' },
             { file: 'monochrome-ledger.html', name: 'Monochrome Ledger', accent: '#111111', style: 'mono' },
             { file: 'slate-split.html', name: 'Slate Split', accent: '#28535e', style: 'split' },
-            { file: 'blue-horizon-split.html', name: 'Blue Horizon Split', accent: '#1f385c', style: 'splitblue' }
+            { file: 'blue-horizon-split.html', name: 'Blue Horizon Split', accent: '#1f385c', style: 'splitblue' },
+            { file: 'blue-banner-professional.html', name: 'Blue Banner Professional', accent: '#155f82', style: 'bluebanner' }
         ];
         const TEMPLATE_COLOR_PRESETS = ['#2b2b2b', '#0f6cbd', '#155e95', '#1f8f63', '#c0392b', '#7b4db3'];
 

--- a/cv-builder/index.html
+++ b/cv-builder/index.html
@@ -506,6 +506,7 @@
             <option value="monochrome-ledger.html">Monochrome Ledger</option>
             <option value="slate-split.html">Slate Split</option>
             <option value="blue-horizon-split.html">Blue Horizon Split</option>
+            <option value="blue-banner-professional.html">Blue Banner Professional</option>
         </select>
 
         <div class="preview-wrapper">


### PR DESCRIPTION
# PR: Add Blue Banner Professional CV Template

**Branch:** `feature/blue-banner-professional-template`
**Base:** `master`
**Author:** Ruthuja
**Date:** 2026-06-23

---

## Overview

This PR integrates a flat, document-style CV — as a fully dynamic, data-driven template inside the My Student Club CV Builder. The template joins the existing pool of 22 templates and is selectable from the template picker sidebar.

---

## Background

`temp4.html` was a standalone static HTML resume file with hardcoded content. The CV builder uses a `postMessage`-based architecture where a central editor (`index.html` + `cv-script.js`) pushes a `cvData` JSON payload into an `<iframe>`, and a shared rendering engine (`cv-common.js`) injects that data into the template via `data-field` and `data-list` DOM attributes.

To integrate `temp4.html`, all static content had to be stripped out and replaced with the correct data hooks, section ordering wrappers, and the `cv-common.js` script inclusion.

---

## How the CV Builder Works (Architecture Summary)

```
index.html  (left panel — form editor)
    │
    │  window.postMessage({ type: 'update-cv', payload: cvData })
    ▼
<iframe src="*.html">  (right panel — live preview)
    │
    └── cv-common.js  (shared rendering engine, included in every template)
            │
            ├── renderCV(payload)
            │       ├── setHTML('[data-field="name"]', ...)
            │       ├── updateList('education-list', ...)  ← clones .template rows
            │       ├── applySectionOrder([...])           ← reorders .sortable-section divs
            │       └── applyTemplateAccent(hex)           ← overrides CSS variables
            │
            └── posts { type: 'cv-frame-ready' } on DOMContentLoaded
```

**Key contracts every template must honour:**

| What | How |
|---|---|
| Dynamic text fields | `data-field="name"`, `data-field="summary"`, etc. on any element |
| Repeating list rows | `id="education-list"` container with a hidden `class="template"` child that `cv-common.js` clones per entry |
| Simple bullet lists | `data-list="achievements"` on a `<ul>` |
| Sortable sections | `<div class="sortable-section" data-section-id="education">` wrapper |
| Theme accent colour | CSS variables `--blue-header`, `--accent-color`, etc. overridden by `applyTemplateAccent()` |
| Scaling | `shrinkContentToFit()` + `scaleToFit()` functions in each template's `<script>` |

---

## Source Template Analysis (`temp4.html`)

### Visual Style
- **Blue header banners** (`.section-banner`) — solid `#155f82` background, white text, uppercase
- **Light blue row backgrounds** (`.item-row`) — `#dbe8f8`, used for each education/experience entry
- **Two-column rows** — bold title/name left, italic date right (`justify-content: space-between`)
- **Indented subtext** (`.edu-subtext`) — smaller grey text below education rows for remarks
- **Sub-section titles** (`.sub-section-title`) — light blue background, used as category headings within experience
- **A4 fixed layout** — 1000×1414 px canvas, scales to viewport via JS transform

### Sections in the original
| Original Section | Maps to `cvData` field |
|---|---|
| Header (name + contact) | `personal.name`, `personal.contact`, `personal.tagline` |
| Career objective tagline | `summary` |
| Education | `education[]` |
| Work Experience | `experience[]` |
| Extra Curricular / Certifications | `certifications[]` |
| Extra Curricular / Projects | `projects[]` |
| Achievements & Awards | `achievements[]` |
| Leadership | `leadership[]` |
| Interests | `interests[]` |
| Skills | `skills` |

### What was hardcoded (stripped out)
- All name, contact, and tagline text
- Every education entry (`item-row` divs with static degree/year text)
- All experience entries and bullet points
- All extra-curricular content

---

## Changes Made

### 1. New file — `cv-builder/blue-banner-professional.html`

Created by adapting `temp4.html`:

**Structural changes:**
- Removed all static content from every section
- Wrapped each section in `<div class="sortable-section" data-section-id="...">` so the Layout reorder drawer works
- Added `data-field` attributes to all text targets (name, tagline, contact, summary, skills)
- Added `id="education-list"`, `id="experience-list"`, `id="projects-list"` containers with hidden `.template` child rows for `cv-common.js` list cloning
- Added `data-list="achievements"`, `data-list="leadership"`, `data-list="interests"`, `data-list="certifications"` on `<ul>` elements
- Added `<script src="cv-common.js"></script>` — wires up the `postMessage` listener automatically
- Added `contact-block` class to the contact div so `cv-common.js` auto-hides it when all contact fields are empty

**CSS additions:**
- `.edu-inst-line` — smaller grey institution name below the degree title
- `.exp-company-line` — smaller grey company name below the role title
- `.header-tagline` — short role subtitle under the candidate name
- `:empty` pseudo-class rules on `.edu-subtext`, `.edu-inst-line`, `.exp-company-line`, `.sub-section-title`, `h1`, `.header-tagline` — hides elements when cv-common.js injects nothing
- `.section-header`, `.section-header-2`, `.section-title` styled identically to `.section-banner` — ensures custom sections injected by `cv-common.js` also get the teal banner style

**Education row layout (per entry):**
```
[ item-row (light blue bg)                          ]
  [ .item-left                    ] [ .item-date    ]
    .item-title  ← data-field="degree"   ← data-field="year"
    .edu-inst-line ← data-field="institution"
[ .edu-subtext ← data-field="remarks"               ]
```

**Experience row layout (per entry):**
```
[ item-row (light blue bg)                          ]
  [ .item-left                    ] [ .item-date    ]
    .item-title  ← data-field="role"     ← data-field="dates"
    .exp-company-line ← data-field="company"
[ .sub-section-title ← data-field="category"       ]  ← hidden when empty
[ <ul> ← data-list="bullets"                        ]
```

---

### 2. Edit — `cv-builder/index.html`

Added one `<option>` to the hidden `<select>` (used for legacy template switching and PDF worker):

```html
<option value="blue-banner-professional.html">Blue Banner Professional</option>
```

---

### 3. Edit — `cv-builder/cv-script.js`

Added one entry to the `TEMPLATES` array (drives the template picker sidebar and lazy-loaded preview thumbnails):

```js
{ file: 'blue-banner-professional.html', name: 'Blue Banner Professional', accent: '#155f82', style: 'bluebanner' }
```

The `accent` value `#155f82` is the template's native `--blue-header` colour, used as the default theme swatch when this template is active.

---

## Files Changed

```
cv-builder/
├── blue-banner-professional.html   ← NEW
├── index.html                      ← +1 line  (option added to select)
└── cv-script.js                    ← +1 line  (entry added to TEMPLATES array)
```


