### PR TITLE
feat: implement central CV rendering logic and template framework for…

### DIFF
--- a/cv-builder/cv-common.js
+++ b/cv-builder/cv-common.js
@@ -184,6 +184,7 @@ function renderCV(data) {
         setHTMLIn(block, '[data-field="role"]', item.role);
         setHTMLIn(block, '[data-field="company"]', item.company);
         setHTMLIn(block, '[data-field="dates"]', item.dates);
+        setHTMLIn(block, '[data-field="intro"]', item.intro); // Role/firm intro shown once under the header
         setHTMLIn(block, '[data-field="category"]', item.category); // Department/Area like "Business Finance"
         applyExperienceTitleMergeDisplayV2(block, item);
 
@@ -191,8 +192,12 @@ function renderCV(data) {
         if (roleEl) roleEl.style.display = stripTags(item.role || '').trim() ? '' : 'none';
         const categoryEl = block.querySelector('[data-field="category"]');
         if (categoryEl) categoryEl.style.display = stripTags(item.category || '').trim() ? '' : 'none';
+        // Intro belongs to the header, so only the primary entry shows it; subsections hide it.
+        const introEl = block.querySelector('[data-field="intro"]');
+        if (introEl) introEl.style.display = (stripTags(item.intro || '').trim() && !item.titleMergedWithPrevious) ? '' : 'none';
         if (item.titleMergedWithPrevious) {
             if (roleEl) roleEl.style.display = 'none';
+            if (introEl) introEl.style.display = 'none';
             const companyEl = block.querySelector('[data-field="company"]');
             const datesEl = block.querySelector('[data-field="dates"]');
             if (companyEl) companyEl.style.display = 'none';

--- a/cv-builder/cv-script.js
+++ b/cv-builder/cv-script.js
@@ -1,4 +1,4 @@
-        // Promise.withResolvers polyfill for older browsers/devices
+﻿        // Promise.withResolvers polyfill for older browsers/devices
         if (typeof Promise.withResolvers === 'undefined') {
             Promise.withResolvers = function() {
                 let resolve, reject;
@@ -84,14 +84,41 @@
             ],
             experience: [
                 {
-                    role: "Article Trainee",
-                    company: "Firm Name",
-                    dates: "Aug 2024 - Present",
-                    category: "GST & Compliance",
+                    role: "Article Assistant",
+                    company: "Firm Name | Mumbai",
+                    dates: "Dec 2025 - Present",
+                    intro: "Top-tier CA firm (est. 1928) with 14 partners serving 3000+ clients across industries.",
+                    category: "PSU Audit",
                     bullets: [
-                        "Handled preparation and filing of GSTR-1 and GSTR-3B for multi-industry clients with timely compliance.",
-                        "Performed monthly ITC reconciliations and maintained inward/outward registers for GSTR-9 and GSTR-9C readiness.",
-                        "Supported GST departmental audits with documentation, reconciliations, and notice tracking."
+                        "Core audit team member for interim & final statutory audits of Maharashtra's largest state-owned power generation company with ₹40,000 Cr+ turnover.",
+                        "Independently audited Other Current Assets & Receivables using SAP, identifying ₹2,000+ Cr disputed receivables.",
+                        "Conducted field visits across multiple TPS and independently coordinated with officials to manage audit access in restricted zones."
+                    ]
+                },
+                {
+                    role: "",
+                    company: "Firm Name | Mumbai",
+                    dates: "",
+                    intro: "",
+                    category: "RBI Audit",
+                    titleMergedWithPrevious: true,
+                    bullets: [
+                        "Part of audit team for Statutory Audit of RBI, Bhopal Regional Office.",
+                        "Led digital archiving of 3,000+ audit documents in compliance with SA 230.",
+                        "Assisted in preparation of SRM (Summary Review Memorandum) and final audit presentations."
+                    ]
+                },
+                {
+                    role: "",
+                    company: "Firm Name | Mumbai",
+                    dates: "",
+                    intro: "",
+                    category: "Key Contributions",
+                    titleMergedWithPrevious: true,
+                    bullets: [
+                        "Led end-to-end audits of Purchases, Inventory, Trade Payables, Payroll, and Other Expenses across Manufacturing, Chemical, Pharma, and Service sectors.",
+                        "Conducted stock audits using floor-sheet and sheet-floor verification, identifying ₹60+ lakh dead stock.",
+                        "Reported delayed statutory payments (TDS, PF, PT, ESIC, LWF) of ₹2 lakh+ under CARO 2020 Para 3(vii)(a)."
                     ]
                 }
             ],
@@ -842,6 +869,7 @@
                     role: normalizeImportedString(item?.role || ''),
                     company: normalizeImportedString(item?.company || ''),
                     dates: normalizeImportedString(item?.dates || ''),
+                    intro: normalizeImportedString(item?.intro || ''),
                     category: normalizeCategoryHTML(htmlToMultilineText(item?.category || '')),
                     bullets: applyBoldToBulletList(item?.bullets || [], 'experience'),
                     mergedWithPrevious: !!item?.mergedWithPrevious && index > 0,
@@ -1130,6 +1158,7 @@
                     role: normalizeImportedString(entry.role || ''),
                     company: normalizeImportedString(entry.company || ''),
                     dates: normalizeImportedString(entry.dates || ''),
+                    intro: normalizeImportedString(entry.intro || ''),
                     category: normalizeCategoryHTML(htmlToMultilineText(entry.category || '')),
                     mergedWithPrevious: !!entry.mergedWithPrevious && index > 0,
                     titleMergedWithPrevious: !!entry.titleMergedWithPrevious && index > 0 && !entry.mergedWithPrevious,
@@ -1612,6 +1641,11 @@
                         <label>Duration</label>
                         <input class="form-control" value="${exp.dates || ''}" oninput="updateExp(${index}, 'dates', this.value)" placeholder="e.g. Jan 2023 - Present">
                     </div>
+                    ${!isMergedChild && !isTitleMergedChild ? `
+                    <div class="form-group">
+                        <label>Intro / Description (optional)</label>
+                        <textarea class="form-control" style="min-height:60px" oninput="updateExp(${index}, 'intro', this.value)" placeholder="Short italic intro shown once under the header&#10;e.g. Top-tier CA firm (est. 1928) serving 3000+ clients">${exp.intro || ''}</textarea>
+                    </div>` : ''}
                     <div class="form-group" data-section="category">
                         <label>Department / Category (optional)</label>
                         <textarea class="form-control" style="min-height:78px" oninput="updateExp(${index}, 'category', this.value)" placeholder="Add one department/category per line&#10;e.g. Accounting&#10;Auditing & Assurance">${htmlToMultilineText(exp.category || '')}</textarea>
@@ -1631,7 +1665,7 @@
                         </div>
                         <textarea id="exp-bullets-${index}" class="form-control" data-rich-exp-index="${index}" oninput="updateExp(${index}, 'bullets', this.value)" placeholder="Add bullet points with formatting">${bulletsToRichHTML(exp.bullets || [])}</textarea>
                     </div>
-                    ${!isMergedChild && !isTitleMergedChild ? `
+                    ${!isMergedChild ? `
                     <button type="button" class="btn-dashed" style="margin-top:10px; font-size:11px; color:#0369a1; border-color:#bae6fd;" onclick="addSubsectionAfter(${index})" title="Add a subsection under this role (reuses the same title)">
                         + Add Subsection
                     </button>` : ''}
@@ -1797,7 +1831,7 @@
         }
 
         function addExperience() {
-            cvData.experience.push({ role: "", company: "", dates: "", category: "", bullets: [], mergedWithPrevious: false, titleMergedWithPrevious: false });
+            cvData.experience.push({ role: "", company: "", dates: "", intro: "", category: "", bullets: [], mergedWithPrevious: false, titleMergedWithPrevious: false });
             normalizeExperienceMerges();
             renderExpInputs();
             postToFrame();
@@ -1842,7 +1876,7 @@
             postToFrame();
         }
         function addSubsectionAfter(i) {
-            const newEntry = { role: "", company: cvData.experience[i]?.company || "", dates: "", category: "", bullets: [], mergedWithPrevious: false, titleMergedWithPrevious: true };
+            const newEntry = { role: "", company: cvData.experience[i]?.company || "", dates: "", intro: "", category: "", bullets: [], mergedWithPrevious: false, titleMergedWithPrevious: true };
             cvData.experience.splice(i + 1, 0, newEntry);
             normalizeExperienceMerges();
             renderExpInputs();
@@ -2301,7 +2335,8 @@
             { file: 'monochrome-ledger.html', name: 'Monochrome Ledger', accent: '#111111', style: 'mono' },
             { file: 'slate-split.html', name: 'Slate Split', accent: '#28535e', style: 'split' },
             { file: 'blue-horizon-split.html', name: 'Blue Horizon Split', accent: '#1f385c', style: 'splitblue' },
-            { file: 'blue-banner-professional.html', name: 'Blue Banner Professional', accent: '#155f82', style: 'bluebanner' }
+            { file: 'blue-banner-professional.html', name: 'Blue Banner Professional', accent: '#155f82', style: 'bluebanner' },
+            { file: 'navy-professional.html', name: 'Navy Professional', accent: '#1F4E79', style: 'navypro' }
         ];
         const TEMPLATE_COLOR_PRESETS = ['#2b2b2b', '#0f6cbd', '#155e95', '#1f8f63', '#c0392b', '#7b4db3'];
 

--- a/cv-builder/index.html
+++ b/cv-builder/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html lang="en">
 
 <head>
@@ -507,6 +507,7 @@
             <option value="slate-split.html">Slate Split</option>
             <option value="blue-horizon-split.html">Blue Horizon Split</option>
             <option value="blue-banner-professional.html">Blue Banner Professional</option>
+            <option value="navy-professional.html">Navy Professional</option>
         </select>
 
         <div class="preview-wrapper">

--- a/cv-builder/navy-professional.html
+++ b/cv-builder/navy-professional.html
@@ -1,0 +1,840 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <title>My CV</title>
+    <style>
+        :root {
+            --banner-color: #1f4e79;
+            --edu-header-bg: #DEEAF6;
+            --edu-exam-bg: #F1F1F1;
+            --work-sub-bg: #DDEBF7;
+            --header-box-bg: #F1F1F1;
+            --text-black: #000000;
+            --text-navy: #001F5F;
+            --text-link: #0461C1;
+            --bg-white: #ffffff;
+            --font-main: 'Arial', sans-serif;
+            --viewer-bg: #525659;
+            --ref-width: 1000px;
+            --ref-height: 1414px;
+            --content-scale: 1;
+        }
+
+        html {
+            -webkit-text-size-adjust: 100%;
+            text-size-adjust: 100%;
+        }
+
+        * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+            -webkit-print-color-adjust: exact;
+            print-color-adjust: exact;
+        }
+
+        body {
+            background-color: var(--viewer-bg);
+            font-family: var(--font-main);
+            overflow-x: hidden;
+            min-height: 100vh;
+            width: 100vw;
+            margin: 0;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+
+        #zoom-wrapper {
+            width: 100%;
+            overflow: hidden;
+            display: flex;
+            justify-content: center;
+            padding-top: 20px;
+            padding-bottom: 20px;
+        }
+
+        .resume-container {
+            width: var(--ref-width);
+            height: var(--ref-height);
+            background: var(--bg-white);
+            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
+            position: relative;
+            padding: calc(45px * var(--content-scale)) calc(40px * var(--content-scale)) calc(35px * var(--content-scale));
+            display: flex;
+            flex-direction: column;
+            flex-shrink: 0;
+            transform-origin: top center;
+            font-size: calc(16.5px * var(--content-scale));
+            color: var(--text-black);
+            line-height: 1.22;
+        }
+
+        .resume-container::before {
+            content: "";
+            position: absolute;
+            top: calc(24px * var(--content-scale));
+            bottom: calc(24px * var(--content-scale));
+            left: calc(24px * var(--content-scale));
+            right: calc(24px * var(--content-scale));
+            border: calc(1.5px * var(--content-scale)) solid #000000;
+            pointer-events: none;
+            z-index: 10;
+        }
+
+        .header-box {
+            background-color: var(--header-box-bg);
+            border: calc(1.5px * var(--content-scale)) solid #000000;
+            padding: calc(8px * var(--content-scale)) calc(12px * var(--content-scale)) calc(8px * var(--content-scale));
+
+        }
+
+        .header-name {
+            font-size: calc(25px * var(--content-scale));
+            font-weight: bold;
+            color: #000000;
+            margin-bottom: calc(4px * var(--content-scale));
+        }
+
+        .header-name:empty {
+            display: none;
+        }
+
+        .header-tagline {
+            font-size: calc(13px * var(--content-scale));
+            font-weight: bold;
+            color: #333;
+            margin-bottom: calc(3px * var(--content-scale));
+        }
+
+        .header-tagline:empty {
+            display: none;
+        }
+
+        .header-contact {
+            font-size: calc(15px * var(--content-scale));
+            line-height: 1.35;
+        }
+
+        .header-contact:empty {
+            display: none;
+        }
+
+        .section-banner,
+        .section-header,
+        .section-header-2,
+        .section-title {
+            background-color: var(--banner-color);
+            color: #ffffff;
+            font-weight: bold;
+            font-size: calc(15.5px * var(--content-scale));
+            padding: calc(4px * var(--content-scale)) calc(8px * var(--content-scale));
+            text-align: left;
+            margin-top: 0;
+            margin-bottom: calc(6px * var(--content-scale));
+        }
+
+        .sortable-section[data-section-id="education"] .section-header,
+        .sortable-section[data-section-id="experience"] .section-header {
+            margin-top: 0 !important;
+        }
+
+        .we-section-banner {
+            text-align: left;
+            margin-top: calc(12px * var(--content-scale));
+            margin-bottom: calc(6px * var(--content-scale));
+        }
+
+        .summary-text {
+            font-size: calc(14.5px * var(--content-scale));
+            line-height: 1.3;
+            text-align: justify;
+
+        }
+
+        .summary-text:empty {
+            display: none;
+        }
+
+        .edu-table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 0;
+            font-size: calc(14.5px * var(--content-scale));
+        }
+
+        .edu-table th,
+        .edu-table td {
+            border: calc(0.5px * var(--content-scale)) solid #000000;
+            padding: calc(3px * var(--content-scale)) calc(5px * var(--content-scale));
+            vertical-align: middle;
+        }
+
+        .edu-table thead th {
+            background-color: var(--edu-header-bg);
+            font-weight: bold;
+            text-align: center;
+        }
+
+        .edu-table col.c0 {
+            width: 19.0%;
+        }
+
+        .edu-table col.c1 {
+            width: 34.0%;
+        }
+
+        .edu-table col.c4 {
+            width: 11.0%;
+        }
+
+        .edu-table col.c2 {
+            width: 9.0%;
+        }
+
+        .edu-table col.c3 {
+            width: 27.0%;
+        }
+
+        .edu-table tbody td.exam {
+            background-color: var(--edu-exam-bg);
+            text-align: center;
+        }
+
+        .edu-table tbody td.board {
+            text-align: center;
+        }
+
+        .edu-table tbody td.year {
+            text-align: center;
+        }
+
+        .edu-table tbody td.marks {
+            font-weight: bold;
+            text-align: center;
+        }
+
+        .edu-table tbody td.rem {
+            text-align: center;
+        }
+
+        .we-header-row {
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+            flex-wrap: nowrap;
+            margin-top: 0;
+            margin-bottom: calc(4px * var(--content-scale));
+            line-height: 1.3;
+        }
+
+        .we-left {
+            display: flex;
+            align-items: baseline;
+            flex-wrap: nowrap;
+            flex-shrink: 1;
+            min-width: 0;
+        }
+
+        .we-job {
+            font-weight: bold;
+            font-size: calc(14.5px * var(--content-scale));
+            white-space: nowrap;
+        }
+
+        .we-firm {
+            font-weight: bold;
+            font-size: calc(14.5px * var(--content-scale));
+            color: var(--text-navy);
+            white-space: nowrap;
+        }
+
+        .we-firm:not(:empty)::before {
+            content: " \00A0|\00A0 ";
+            color: var(--text-black);
+        }
+
+        .we-date {
+            font-weight: bold;
+            font-size: calc(14.5px * var(--content-scale));
+            white-space: nowrap;
+            margin-left: calc(10px * var(--content-scale));
+            flex-shrink: 0;
+        }
+
+        .we-category {
+            background-color: var(--work-sub-bg);
+            font-weight: bold;
+            border: calc(0.5px * var(--content-scale)) solid #000000;
+            padding: calc(3px * var(--content-scale)) calc(6px * var(--content-scale));
+            margin-top: calc(3px * var(--content-scale));
+            margin-bottom: calc(2px * var(--content-scale));
+            font-size: calc(14.5px * var(--content-scale));
+        }
+
+        .we-category:empty {
+            display: none;
+        }
+
+        .we-italic {
+            font-style: italic;
+            font-size: calc(13px * var(--content-scale));
+            line-height: 1.3;
+            text-align: justify;
+            margin-top: calc(2px * var(--content-scale));
+            margin-bottom: calc(3px * var(--content-scale));
+        }
+
+        .we-italic:empty {
+            display: none;
+        }
+
+        #experience-list ul {
+            list-style-type: none;
+            margin-left: 0;
+            padding-left: 0;
+            margin-top: 0;
+            margin-bottom: 0;
+        }
+
+        #experience-list li {
+            padding: calc(2.5px * var(--content-scale)) calc(6px * var(--content-scale));
+            line-height: 1.22;
+            text-align: justify;
+            font-size: calc(14.5px * var(--content-scale));
+            margin-bottom: 0;
+        }
+
+        #experience-list li:last-child {
+            margin-bottom: calc(4px * var(--content-scale));
+        }
+
+        .project-title {
+            font-weight: bold;
+            font-size: calc(14.5px * var(--content-scale));
+            margin-top: calc(4px * var(--content-scale));
+            margin-bottom: calc(2px * var(--content-scale));
+            display: block;
+        }
+
+        .project-desc {
+            font-style: italic;
+            font-size: calc(13px * var(--content-scale));
+            margin-bottom: calc(2px * var(--content-scale));
+        }
+
+        .project-desc:empty {
+            display: none;
+        }
+
+        #projects-list ul {
+            list-style-type: none;
+            margin-left: 0;
+            padding-left: 0;
+            margin-top: 0;
+            margin-bottom: 0;
+        }
+
+        #projects-list li {
+            padding: calc(2px * var(--content-scale)) calc(6px * var(--content-scale));
+            line-height: 1.22;
+            text-align: justify;
+            font-size: calc(14.5px * var(--content-scale));
+        }
+
+        ul {
+            list-style-type: disc;
+            margin-left: calc(20px * var(--content-scale));
+            margin-bottom: calc(3px * var(--content-scale));
+            margin-top: calc(2px * var(--content-scale));
+        }
+
+        li {
+            margin-bottom: calc(1.5px * var(--content-scale));
+            text-align: justify;
+            line-height: 1.25;
+            font-size: calc(14.5px * var(--content-scale));
+        }
+
+        li:last-child {
+            margin-bottom: 0;
+        }
+
+        .sortable-section[data-section-id="skills"] {
+            display: flex;
+            flex-direction: column;
+        }
+
+        /* Injected custom sections sit in normal flow as the last block(s); never let
+           an earlier section grow and push them past the page border. */
+        .resume-container>.sortable-section {
+            flex: 0 0 auto;
+        }
+
+        .skills-table {
+            width: 100%;
+            border-collapse: collapse;
+            table-layout: fixed;
+            font-size: calc(14.5px * var(--content-scale));
+        }
+
+        .skills-table td {
+            border: none;
+            padding: calc(2.5px * var(--content-scale)) calc(4px * var(--content-scale));
+            vertical-align: top;
+            line-height: 1.3;
+        }
+
+        .skills-table td.lbl {
+            width: 14.5%;
+            font-weight: bold;
+            white-space: nowrap;
+            padding-right: calc(6px * var(--content-scale));
+        }
+
+        .skills-table td.val {
+            width: 85.5%;
+        }
+
+        .skills-table .val [data-field="skills"],
+        .skills-table .val [data-field="skills"] * {
+            font-size: calc(14.5px * var(--content-scale));
+            line-height: 1.3;
+        }
+
+        .skills-table .val ul {
+            list-style-type: none;
+            margin-left: 0;
+            padding-left: 0;
+            margin-top: 0;
+            margin-bottom: 0;
+        }
+
+        .skills-table .val li {
+            padding-left: calc(8px * var(--content-scale));
+            text-indent: calc(-8px * var(--content-scale));
+            margin-bottom: calc(1px * var(--content-scale));
+            text-align: left;
+            font-size: calc(14.5px * var(--content-scale));
+            line-height: 1.3;
+        }
+
+        .skills-table .val li::before {
+            content: "\2022\00A0\00A0";
+        }
+
+        /* Certifications & custom-section bullet lists — val-bullet style matching temp5 */
+        .sortable-section[data-section-id="certifications"] ul,
+        ul.bullet-list {
+            list-style-type: none;
+            margin-left: 0;
+            padding-left: 0;
+            margin-top: 0;
+            margin-bottom: 0;
+        }
+
+        .sortable-section[data-section-id="certifications"] li,
+        ul.bullet-list li {
+            display: flex;
+            align-items: baseline;
+            padding-left: 0;
+            text-indent: 0;
+            margin-bottom: calc(2px * var(--content-scale));
+            line-height: 1.3;
+            font-size: calc(14.5px * var(--content-scale));
+            text-align: left;
+            /* `anywhere` (not break-word) lets the flex text item shrink so long
+               unbroken tokens wrap instead of overflowing the page border. */
+            overflow-wrap: anywhere;
+        }
+
+        .sortable-section[data-section-id="certifications"] li>*,
+        ul.bullet-list li>* {
+            min-width: 0;
+        }
+
+        .sortable-section[data-section-id="certifications"] li::before,
+        ul.bullet-list li::before {
+            content: "\2022\00A0\00A0";
+            flex-shrink: 0;
+        }
+
+        .sortable-section[data-section-id="certifications"] li b,
+        .sortable-section[data-section-id="certifications"] li strong,
+        ul.bullet-list li b,
+        ul.bullet-list li strong {
+            font-weight: bold;
+        }
+
+        /* Ensure injected custom sections always get the themed banner */
+        .custom-section-injected .section-header,
+        [data-custom-section-root] .section-header {
+            background-color: var(--banner-color) !important;
+            color: #ffffff !important;
+            font-weight: bold !important;
+            display: block !important;
+            margin-top: calc(12px * var(--content-scale));
+        }
+
+        .skills-table tr:has(td > ul:empty) {
+            display: none;
+        }
+
+        @media print {
+            @page {
+                size: A4 portrait;
+                margin: 0;
+            }
+
+            html,
+            body {
+                width: 210mm;
+                height: 297mm;
+                margin: 0 !important;
+                padding: 0 !important;
+                overflow: hidden !important;
+                background: #ffffff !important;
+            }
+
+            #zoom-wrapper {
+                display: block !important;
+                width: 100% !important;
+                height: auto !important;
+                margin: 0 !important;
+                padding: 0 !important;
+                overflow: visible !important;
+                transform: none !important;
+            }
+
+            .resume-container {
+                width: 1000px !important;
+                margin: 0 auto !important;
+                box-shadow: none !important;
+                outline: none !important;
+                zoom: 0.7937;
+                transform-origin: top center;
+                position: relative !important;
+            }
+        }
+    </style>
+</head>
+
+<body>
+    <div id="zoom-wrapper">
+        <div class="resume-container" id="cv-page">
+
+            <div class="header-box">
+                <div class="header-name" data-field="name"></div>
+                <div class="header-tagline" data-field="tagline"></div>
+                <div class="header-contact contact-block" data-field="contact"></div>
+            </div>
+
+            <div class="sortable-section" data-section-id="summary">
+                <div class="section-header">Career Objective</div>
+                <div class="summary-text" data-field="summary"></div>
+            </div>
+
+            <div class="sortable-section" data-section-id="education">
+                <div class="section-header">Educational &amp; Professional Qualifications</div>
+                <table class="edu-table">
+                    <colgroup>
+                        <col class="c0">
+                        <col class="c1">
+                        <col class="c4">
+                        <col class="c2">
+                        <col class="c3">
+                    </colgroup>
+                    <thead>
+                        <tr>
+                            <th>Examination</th>
+                            <th>Board / Institute</th>
+                            <th>Year</th>
+                            <th>Marks</th>
+                            <th>Remarks</th>
+                        </tr>
+                    </thead>
+                    <tbody id="education-list">
+                        <tr class="template" style="display:none;">
+                            <td class="exam" data-field="degree"></td>
+                            <td class="board" data-field="institution"></td>
+                            <td class="year" data-field="year"></td>
+                            <td class="marks" data-field="marks"></td>
+                            <td class="rem" data-field="remarks"></td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+
+            <div class="sortable-section" data-section-id="experience">
+                <div class="section-header we-section-banner">Work Experience</div>
+                <div id="experience-list">
+                    <div class="template" style="display:none;">
+                        <div class="we-header-row work-exp-row">
+                            <div class="we-left">
+                                <span class="we-job" data-field="role"></span><span class="we-firm"
+                                    data-field="company"></span>
+                            </div>
+                            <span class="we-date" data-field="dates"></span>
+                        </div>
+                        <div class="we-italic" data-field="intro"></div>
+                        <div class="we-category" data-field="category"></div>
+                        <ul data-list="bullets"></ul>
+                    </div>
+                </div>
+            </div>
+
+            <div class="sortable-section" data-section-id="projects">
+                <div class="section-header">Projects</div>
+                <div id="projects-list">
+                    <div class="template" style="display:none;">
+                        <span class="project-title" data-field="title"></span>
+                        <div class="project-desc" data-field="description"></div>
+                        <ul data-list="bullets"></ul>
+                    </div>
+                </div>
+            </div>
+
+            <div class="sortable-section" data-section-id="certifications">
+                <div class="section-header">Certifications &amp; Trainings</div>
+                <ul data-list="certifications"></ul>
+            </div>
+
+            <div class="sortable-section" data-section-id="skills">
+                <div class="section-header">Skills, Achievements &amp; Additional Information</div>
+                <table class="skills-table" data-preserve-label-columns>
+                    <colgroup>
+                        <col style="width:14.5%">
+                        <col style="width:85.5%">
+                    </colgroup>
+                    <tbody>
+                        <tr>
+                            <td class="lbl" style="vertical-align:top;">Technical Skills</td>
+                            <td class="val">
+                                <div data-field="skills"></div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td class="lbl" style="vertical-align:top;">Interests and Hobbies<d>
+                            <td class="val">
+                                <ul data-list="interests"></ul>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td class="lbl" style="vertical-align:top;">Achievements</td>
+                            <td class="val">
+                                <ul data-list="achievements"></ul>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td class="lbl" style="vertical-align:top;">Leadership</td>
+                            <td class="val">
+                                <ul data-list="leadership"></ul>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+
+
+        </div>
+
+        <!-- Hidden reference element for custom-section cloning — never shown to user -->
+        <div class="sortable-section" data-section-id="achievements" style="display:none;" aria-hidden="true">
+            <div class="section-header"></div>
+            <ul data-list="__csr__"></ul>
+        </div>
+    </div>
+
+    <script src="cv-common.js"></script>
+    <script>
+        /* ── Helpers ─────────────────────────────────────────────────────────── */
+        function esc(s) {
+            return String(s || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+        }
+
+        /* ── Capture raw data so template can repair what cv-common.js might miss */
+        var _lastCerts = null;
+        var _lastCustomSections = null;
+        var _lastPersonal = null;
+        window.addEventListener('message', function (ev) {
+            try {
+                var d = (typeof ev.data === 'string') ? JSON.parse(ev.data) : ev.data;
+                if (!d) return;
+                // The app posts { type:'update-cv', payload:{...} } — unwrap it.
+                if (d.type === 'update-cv' && d.payload) d = d.payload;
+                if (Array.isArray(d.certifications)) _lastCerts = d.certifications;
+                if (Array.isArray(d.customSections)) _lastCustomSections = d.customSections;
+                if (d.personal) _lastPersonal = d.personal;
+            } catch (e) { }
+        });
+
+        /* ── Render the contact line with bold text labels (Phone:/Email:/LinkedIn:)
+         *    exactly like the reference, replacing cv-common.js's icon+link version. */
+        function renderContactNavy() {
+            var el = document.querySelector('#cv-page [data-field="contact"]');
+            if (!el || !_lastPersonal) return;
+            var p = _lastPersonal;
+            var navy = 'var(--text-navy)', link = 'var(--text-link)';
+            var out = [];
+            if ((p.phone || '').trim())
+                out.push('<b>Phone<span style="color:' + navy + '">:</span></b> <span style="color:' + navy + '">' + esc(p.phone) + '</span>');
+            if ((p.email || '').trim())
+                out.push('<b>Email:</b> ' + esc(p.email));
+            if ((p.linkedin || '').trim())
+                out.push('<b>LinkedIn:</b> <span style="color:' + link + '">' + esc(p.linkedin) + '</span>');
+            if ((p.location || '').trim())
+                out.push(esc(p.location));
+            if (!out.length) return;
+            el.innerHTML = out.join('<b>  |  </b>');
+            el.style.display = '';
+        }
+
+        /* ── Re-render certifications with bold name ─────────────────────────── */
+        function renderCertsBold() {
+            var ul = document.querySelector('[data-list="certifications"]');
+            if (!ul) return;
+            var certs = _lastCerts;
+            if (!certs || !certs.length) return;
+            ul.innerHTML = certs.map(function (c) {
+                if (!c) return '';
+                /* plain-string format */
+                if (typeof c === 'string') {
+                    var ci = c.indexOf(':');
+                    if (ci > 0 && ci <= 40)
+                        return '<li><b>' + esc(c.slice(0, ci + 1)) + '</b>' + esc(c.slice(ci + 1)) + '</li>';
+                    return '<li>' + esc(c) + '</li>';
+                }
+                /* object format { name, issuer } — **Name:** Issuer */
+                var name = (c.name || '').trim();
+                var issuer = (c.issuer || '').trim();
+                if (!name && !issuer) return '';
+                var ci = name.indexOf(':');
+                if (ci > 0 && ci <= 40) {
+                    var boldPart = name.slice(0, ci + 1);
+                    var rest = name.slice(ci + 1).trim();
+                    if (issuer) rest = rest ? rest + ' (' + issuer + ')' : issuer;
+                    return '<li><b>' + esc(boldPart) + '</b>' + (rest ? ' ' + esc(rest) : '') + '</li>';
+                }
+                return '<li><b>' + esc(name) + ':</b>' + (issuer ? ' ' + esc(issuer) : '') + '</li>';
+            }).filter(Boolean).join('');
+        }
+        function scaleToFit() {
+            const page = document.getElementById('cv-page');
+            const targetWidth = window.innerWidth - 20;
+            const refWidth = 1000;
+            const scale = targetWidth < refWidth ? targetWidth / refWidth : 1;
+            page.style.transform = 'scale(' + scale + ')';
+            const scaledH = page.offsetHeight * scale;
+            page.style.marginBottom = '-' + (page.offsetHeight - scaledH) + 'px';
+        }
+        function shrinkContentToFit() {
+            renderContactNavy();
+            renderCertsBold();
+            // Keep the combined Skills/Achievements block directly below Certifications,
+            // regardless of the saved section order.
+            var _page = document.getElementById('cv-page');
+            var _certs = _page && _page.querySelector('.sortable-section[data-section-id="certifications"]');
+            var _skills = _page && _page.querySelector('.sortable-section[data-section-id="skills"]');
+            if (_certs && _skills && _certs.parentElement === _skills.parentElement) {
+                _certs.after(_skills);
+            }
+            // Re-apply fixed layout to skills-table — stabilizeSectionLayouts() overrides it with auto
+            var st = document.querySelector('.skills-table');
+            if (st) st.style.setProperty('table-layout', 'fixed', 'important');
+            // Follow the chosen color theme. cv-common.js's applyTemplateAccent() sets
+            // --accent-color (and a light --sub-header-bg) when a theme is picked; we map
+            // those onto this template's banner + light-box variables, falling back to the
+            // default navy palette when no theme is active. Every banner is then painted
+            // consistently (including injected custom sections).
+            var _root = document.documentElement;
+            var _cs = getComputedStyle(_root);
+            var _accent = (_cs.getPropertyValue('--accent-color') || '').trim();
+            if (_accent) {
+                var _lightBox = (_cs.getPropertyValue('--sub-header-bg') || '').trim() || _accent;
+                _root.style.setProperty('--banner-color', _accent);
+                _root.style.setProperty('--work-sub-bg', _lightBox);
+                _root.style.setProperty('--edu-header-bg', _lightBox);
+            } else {
+                _root.style.setProperty('--banner-color', '#1F4E79');
+                _root.style.setProperty('--work-sub-bg', '#DDEBF7');
+                _root.style.setProperty('--edu-header-bg', '#DEEAF6');
+            }
+            var _banner = _accent || '#1F4E79';
+            document.querySelectorAll('#cv-page .section-header, #cv-page .section-banner, #cv-page .section-title, #cv-page .section-header-2').forEach(function (h) {
+                h.style.setProperty('background-color', _banner, 'important');
+                h.style.setProperty('color', '#ffffff', 'important');
+                h.style.setProperty('border-color', _banner, 'important');
+            });
+            // Fix custom section headers — apply the theme banner colour AND correct title text
+            document.querySelectorAll('.custom-section-injected, [data-custom-section-root]').forEach(function (wrapper) {
+                var header = wrapper.querySelector('.section-header');
+                if (!header) return;
+                header.style.setProperty('background-color', _banner, 'important');
+                header.style.setProperty('color', '#ffffff', 'important');
+                header.style.setProperty('font-weight', 'bold', 'important');
+                header.style.setProperty('display', 'block', 'important');
+                // Re-apply the correct title from the raw payload
+                var secId = wrapper.getAttribute('data-custom-section-root') || wrapper.getAttribute('data-section-id') || '';
+                if (!secId || !_lastCustomSections) return;
+                var sec = null;
+                for (var i = 0; i < _lastCustomSections.length; i++) {
+                    if (_lastCustomSections[i] && _lastCustomSections[i].id === secId) { sec = _lastCustomSections[i]; break; }
+                }
+                if (!sec) return;
+                var expectedTitle = ((sec.title || '').trim() || 'Custom Section').toUpperCase();
+                if (header.textContent.trim() !== expectedTitle) header.textContent = expectedTitle;
+            });
+            const page = document.getElementById('cv-page');
+            const maxH = 1414;
+            page.style.minHeight = 'none';
+            let s = 1.0;
+            document.documentElement.style.setProperty('--content-scale', s);
+            // Detect overflow using the last visible child's bottom edge, leaving a
+            // margin for the container's bottom padding (35px) so content always
+            // stays inside the drawn border (inset 24px). Custom sections injected
+            // by cv-common.js are appended last, so this measures them too.
+            function pageOverflows() {
+                var kids = Array.from(page.children).filter(function (c) { return c.offsetHeight > 0; });
+                if (!kids.length) return page.scrollHeight > maxH;
+                var last = kids[kids.length - 1];
+                return (last.offsetTop + last.offsetHeight) > (maxH - 40);
+            }
+            for (var i = 0; i < 100 && pageOverflows(); i++) {
+                s = Math.max(s - 0.005, 0.50);
+                document.documentElement.style.setProperty('--content-scale', s);
+            }
+            page.style.minHeight = maxH + 'px';
+        }
+        let _transform = '', _marginBottom = '';
+        function enablePrintMode() {
+            const page = document.getElementById('cv-page');
+            _transform = page.style.transform;
+            _marginBottom = page.style.marginBottom;
+            page.style.transform = 'scale(1)';
+            page.style.marginBottom = '0px';
+            shrinkContentToFit();
+        }
+        function disablePrintMode() {
+            const page = document.getElementById('cv-page');
+            page.style.transform = _transform || '';
+            page.style.marginBottom = _marginBottom || '';
+            scaleToFit();
+        }
+        window.addEventListener('load', function () {
+            shrinkContentToFit();
+            scaleToFit();
+            const mq = window.matchMedia('print');
+            if (mq.addEventListener) mq.addEventListener('change', e => e.matches ? enablePrintMode() : disablePrintMode());
+            else if (mq.addListener) mq.addListener(e => e.matches ? enablePrintMode() : disablePrintMode());
+            window.addEventListener('beforeprint', enablePrintMode);
+            window.addEventListener('afterprint', disablePrintMode);
+        });
+        let _rt;
+        window.addEventListener('resize', () => { clearTimeout(_rt); _rt = setTimeout(scaleToFit, 100); });
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
# Navy Professional CV Template — Implementation & Fixes

## Summary

Builds out and polishes the **Navy Professional** CV template (a Chartered-Accountant–style
resume) in the CV Builder SPA so it matches the reference design. The template is data-driven:
the editor (`cv-script.js`) posts a `{ type: 'update-cv', payload }` message to the preview
`<iframe>`, where `cv-common.js` renders the shared sections and the template's own inline
script applies template-specific touches.

This PR adds the Work Experience department structure, an intro/description line, a contact
line with text labels, an education Year column, color-theme support, and a number of layout
and ordering fixes.

## Files changed

| File | Scope | What changed |
|------|-------|--------------|
| `cv-builder/navy-professional.html` | Template-local | Most layout, styling, and render logic |
| `cv-builder/cv-common.js` | Shared renderer | Backward-compatible experience `intro` rendering |
| `cv-builder/cv-script.js` | Shared editor | Experience intro field + "Add Subsection" availability + seed data |
| `cv-builder/index.html` | App | "Navy Professional" template option |

> `cv-common.js` and `cv-script.js` are shared by every template; all changes there are
> additive/backward-compatible (no-ops for templates that don't use the new fields).

---

## Changes by area

### 1. Work Experience — header → intro → departments
- Each **department** (e.g. *PSU Audit*, *RBI Audit*, *Key Contributions*) is authored as its
  own experience entry using the existing **Subsection** mechanism (`titleMergedWithPrevious`).
  The first entry renders the role/company/dates header; subsequent subsections hide the header
  and render only their own `.we-category` blue box + bullets.
- Layout produced: `Header → Intro → Department → Content → Department → Content`.
- Added an optional **Intro / Description** field (italic line under the header), shown only on
  the primary entry.
  - `navy-professional.html`: `<div class="we-italic" data-field="intro">` + `.we-italic` styles.
  - `cv-common.js`: `setHTMLIn(block, '[data-field="intro"]', item.intro)` in the experience
    callback, hidden for subsections.
  - `cv-script.js`: "Intro / Description" textarea for primary entries; `intro` added to the seed
    data, both import normalizers, `addExperience()`, and `addSubsectionAfter()`.

### 2. Editor — "+ Add Subsection" after every entry
- `cv-script.js`: the **+ Add Subsection** button now renders under primary entries **and** under
  each subsection (condition changed from `!isMergedChild && !isTitleMergedChild` to
  `!isMergedChild`), so departments can be chained.

### 3. Removed inter-department separator lines
- `navy-professional.html`: dropped the `border-bottom` rule on the last bullet of each
  experience block, so subsections flow cleanly with no horizontal rule between them.

### 4. Contact line — bold text labels
- `navy-professional.html`: `renderContactNavy()` rebuilds `[data-field="contact"]` with bold
  **Phone: / Email: / LinkedIn:** labels (reference style), replacing `cv-common.js`'s
  icon + link version. Phone in navy, LinkedIn in link-blue, location plain.
- Fixed a latent bug in the template's `message` listener: it read `d.certifications` but the app
  posts `{ type:'update-cv', payload }`. It now unwraps `d.payload` first, which also makes the
  certification and custom-section repair logic receive data.

### 5. Education — Year column
- `navy-professional.html`: added a **Year** column (`data-field="year"`, already populated by
  `cv-common.js`) between *Board / Institute* and *Marks*, with a new `<col class="c4">` and
  rebalanced column widths (`19 / 34 / 11 / 9 / 27 %`).

### 6. Section banners — color theme support
- `navy-professional.html`: banners now follow the chosen theme. The render step reads
  `--accent-color` / `--sub-header-bg` (set by `cv-common.js`'s `applyTemplateAccent`) and maps
  them onto this template's `--banner-color`, `--work-sub-bg`, and `--edu-header-bg`, falling
  back to the default navy palette (`#1F4E79`) when no theme is active.
- Custom-section headers use `var(--banner-color)` so they re-color with the theme.
- Education & Work Experience banners sit **attached** to the content directly above them
  (top margin zeroed) per design feedback.

### 7. Section ordering — Skills/Achievements below Certifications
- `navy-professional.html`: a small reorder step in the render keeps the combined
  **Skills, Achievements & Additional Information** block directly after **Certifications &
  Trainings**, regardless of the saved section order.

### 8. Custom sections — overflow & display
- `navy-professional.html`:
  - Removed `flex: 1` from the skills section (it was expanding to fill the fixed-height page and
    pushing injected custom sections past the border); sections now flow naturally.
  - Bullet rows use `display:flex` + `overflow-wrap: anywhere` so long unbroken tokens wrap inside
    the border instead of overflowing.
  - `pageOverflows()` shrink-to-fit accounts for the bottom padding so content stays inside the
    drawn border.
  - Custom-section header titles are repaired from the raw payload (correct title + themed banner).

### 9. Certifications
- Final format: **Name:** Issuer (bold name, then issuer).
- A short-lived **Type** field experiment (`Type: Name — Issuer`) was added and then **reverted**
  per request; the editor, data model, and renderer are back to `{ name, issuer }`.

---

## How to author the reference CV

1. **Experience:** first entry = Role, Firm/Company (`Firm Name | Mumbai`), Duration,
   Intro/Description, first Department (`PSU Audit`) + its bullets.
2. Click **+ Add Subsection** for each further department (`RBI Audit`, `Key Contributions`, …)
   and fill its category + bullets. Headers are shown once; each department gets its own blue box.
3. **Education:** fill Year alongside Marks/Remarks.
4. **Theme:** pick a color theme — all banners and light boxes recolor automatically.

---

## Verification

Rendered the template headless (Chrome `--headless=new --screenshot`) with representative data,
posting `{ type:'update-cv', payload }` into a self-contained copy, and visually compared against
the reference for:

- Contact label line, education table + Year column, navy banners
- Work Experience header → intro → department boxes → bullets (no separator lines)
- Certifications as **Name:** Issuer
- Skills/Achievements rendering below Certifications (even with a reversed saved order)
- Color-theme accent applied to every banner and light box

---

## Notes / follow-ups

- Technical Skills currently comma-splits the skills text into multiple bullets (pre-existing
  `cv-common.js` behavior); not addressed here. Can be made a single clean line if desired.
- Shared-file edits (`cv-common.js`, `cv-script.js`) are backward-compatible, but worth a quick
  regression glance on other templates' experience/certification editors.
