### PR TITLE
fixes: Fixed multiple client feedback bugs and improvement also added…

### DIFF
--- a/articleship.html
+++ b/articleship.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html lang="en">
 
 <head>
@@ -371,7 +371,7 @@
                   points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
               </svg>
             </div>
-            <div style="font-weight: 600; font-size: 0.9rem; color: #1f2937;">CA Fresher (Experienced)</div>
+            <div style="font-weight: 600; font-size: 0.9rem; color: #1f2937;">Experienced CA</div>
           </button>
           <button class="pref-option-btn" data-preference="semi_fresher"
             style="display: flex; align-items: center; gap: 0.75rem; padding: 0.65rem 0.75rem; border: 2px solid #e5e7eb; border-radius: 10px; background: white; cursor: pointer; transition: all 0.2s; text-align: left;">

--- a/ca-articleship-opportunities.html
+++ b/ca-articleship-opportunities.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html lang="en">
 
 <head>
@@ -133,6 +133,9 @@
             </a>
             <a href="/ca-fresher-jobs" class="footer-tab">
                 <span>CA Freshers</span>
+            </a>
+            <a href="/experienced-ca-jobs" class="footer-tab">
+                <span>Experienced CA</span>
             </a>
         </nav>
 
@@ -384,7 +387,7 @@
                                     points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
                             </svg>
                         </div>
-                        <div style="font-weight: 600; font-size: 0.9rem; color: #1f2937;">CA Fresher (Experienced)</div>
+                        <div style="font-weight: 600; font-size: 0.9rem; color: #1f2937;">Experienced CA</div>
                     </button>
                     <button class="pref-option-btn" data-preference="semi_fresher"
                         style="display: flex; align-items: center; gap: 0.75rem; padding: 0.65rem 0.75rem; border: 2px solid #e5e7eb; border-radius: 10px; background: white; cursor: pointer; transition: all 0.2s; text-align: left;">

--- a/ca-fresher-jobs.html
+++ b/ca-fresher-jobs.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html lang="en">
 
 <head>
@@ -131,6 +131,9 @@
             </a>
             <a href="/ca-fresher-jobs" class="footer-tab active">
                 <span>CA Freshers</span>
+            </a>
+            <a href="/experienced-ca-jobs" class="footer-tab">
+                <span>Experienced CA</span>
             </a>
         </nav>
 
@@ -406,7 +409,7 @@
                                     points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
                             </svg>
                         </div>
-                        <div style="font-weight: 600; font-size: 0.9rem; color: #1f2937;">CA Fresher (Experienced)</div>
+                        <div style="font-weight: 600; font-size: 0.9rem; color: #1f2937;">Experienced CA</div>
                     </button>
                     <button class="pref-option-btn" data-preference="semi_fresher"
                         style="display: flex; align-items: center; gap: 0.75rem; padding: 0.65rem 0.75rem; border: 2px solid #e5e7eb; border-radius: 10px; background: white; cursor: pointer; transition: all 0.2s; text-align: left;">

--- a/cv-builder/blue-banner-professional.html
+++ b/cv-builder/blue-banner-professional.html
@@ -7,8 +7,8 @@
     <title>My CV</title>
     <style>
         :root {
-            --blue-header: #155f82;
-            --light-blue-bg: #dbe8f8;
+            --blue-header: var(--header-bg, #155f82);
+            --light-blue-bg: var(--sub-header-bg, #dbe8f8);
             --text-black: #000000;
             --bg-white: #ffffff;
             --font-main: 'Calibri', 'Arial', sans-serif;

--- a/cv-builder/blue-horizon-split.html
+++ b/cv-builder/blue-horizon-split.html
@@ -6,9 +6,9 @@
     <title>CV - Template 16</title>
     <style>
         :root {
-            --bg-header: #1f385c;
-            --text-heading: #4982c2;
-            --navy-line: #1f385c;
+            --bg-header: var(--header-bg, #1f385c);
+            --text-heading: var(--blue-text, #4982c2);
+            --navy-line: var(--blue-deep, #1f385c);
             --text-primary: #111111;
             --bg-white: #ffffff;
             --font-main: 'Segoe UI', Calibri, Arial, sans-serif;

--- a/cv-builder/classic-refined.html
+++ b/cv-builder/classic-refined.html
@@ -9,8 +9,10 @@
            CORE VARIABLES & RESET
            --------------------------------------------------------- */
         :root {
-            --blue-header: #4f81bc;
-            --header-bg: #e6eff7;
+            --blue-header: var(--accent-color, #4f81bc);
+            --header-bg: var(--sub-header-bg, #e6eff7);
+            --table-header-bg: var(--sub-header-bg, #D9D9D9);
+            --sub-bg-grey: var(--sub-bg, #E7E6E6);
             --border-color: #000000;
             --text-black: #000000;
             --bg-white: #ffffff;
@@ -110,7 +112,7 @@
 
         /* SECTION HEADERS */
         .section-header {
-            background-color: #2F557F;
+            background-color: var(--blue-header, #2F557F);
             color: white;
             font-weight: bold;
             padding: calc(4px * var(--content-scale)) calc(8px * var(--content-scale));
@@ -134,7 +136,7 @@
         }
         
         th {
-            background-color: #D9D9D9;
+            background-color: var(--table-header-bg);
             font-weight: bold;
         }
 
@@ -154,7 +156,7 @@
         .job-title-row {
             display: flex;
             justify-content: space-between;
-            background-color: #D9D9D9;
+            background-color: var(--table-header-bg);
             padding: calc(4px * var(--content-scale));
             font-weight: bold;
             border-bottom: 1px solid black;
@@ -167,7 +169,7 @@
         }
 
         .details-label {
-            background-color: #E7E6E6;
+            background-color: var(--sub-bg-grey);
             font-weight: bold;
             padding: calc(5px * var(--content-scale));
             border-right: 1px solid black;
@@ -212,7 +214,7 @@
             width: 140px;
             min-width: 140px;
             font-weight: bold;
-            background-color: #E7E6E6;
+            background-color: var(--sub-bg-grey);
             text-align: center !important;
             vertical-align: middle !important;
             line-height: 1.2;

--- a/cv-builder/cv-common.js
+++ b/cv-builder/cv-common.js
@@ -50,6 +50,9 @@ function renderCV(data) {
     setHTML('[data-field="name"]', data.personal?.name);
     setHTML('[data-field="tagline"]', data.personal?.tagline);
     setHTML('[data-field="contact"]', data.personal?.contact);
+    setHTML('[data-field="highlight1"]', data.personal?.highlight1 || 'Top Academic Performer');
+    setHTML('[data-field="highlight2"]', data.personal?.highlight2 || 'Article Trainee Experience');
+    setHTML('[data-field="highlight3"]', data.personal?.highlight3 || 'Leadership & Awards');
     setHTML('[data-field="phone"]', data.personal?.phone);
     setHTML('[data-field="email"]', data.personal?.email);
     setHTML('[data-field="linkedin"]', data.personal?.linkedin);
@@ -191,7 +194,21 @@ function renderCV(data) {
         const roleEl = block.querySelector('[data-field="role"]');
         if (roleEl) roleEl.style.display = stripTags(item.role || '').trim() ? '' : 'none';
         const categoryEl = block.querySelector('[data-field="category"]');
-        if (categoryEl) categoryEl.style.display = stripTags(item.category || '').trim() ? '' : 'none';
+        if (categoryEl) {
+            const categoryEmpty = !stripTags(item.category || '').trim();
+            categoryEl.style.display = categoryEmpty ? 'none' : '';
+            // When category is hidden, let the bullets column fill the full row width
+            const bulletsCell = categoryEl.nextElementSibling;
+            if (bulletsCell && /^TD$/i.test(bulletsCell.tagName || '')) {
+                if (categoryEmpty) {
+                    bulletsCell.setAttribute('colspan', '2');
+                    bulletsCell.style.setProperty('width', '100%', 'important');
+                } else {
+                    bulletsCell.removeAttribute('colspan');
+                    bulletsCell.style.removeProperty('width');
+                }
+            }
+        }
         // Intro belongs to the header, so only the primary entry shows it; subsections hide it.
         const introEl = block.querySelector('[data-field="intro"]');
         if (introEl) introEl.style.display = (stripTags(item.intro || '').trim() && !item.titleMergedWithPrevious) ? '' : 'none';
@@ -284,6 +301,9 @@ function renderCV(data) {
     enforceExperienceOnlyLeftLabels();
     stabilizeSectionLayouts();
     applyTableFormatSettings(data.tableSettings || {});
+
+    // 12. Configurable section labels (rename / hide the grey left-label cells)
+    applySectionLabels(data.sectionLabels || {});
 
     // 12. Recalculate Layout (Scale/Shrink)
     // These functions exist in the templates script block
@@ -502,6 +522,168 @@ function stabilizeSectionLayouts() {
 function applyTableFormatSettings(tableSettings) {
     applyEducationTableFormat(tableSettings?.education?.columns || {});
 }
+
+/**
+ * Apply user-configurable label text and visibility to the grey left-label cells
+ * in Certifications, Interests, Skills, Achievements, Leadership sections.
+ *
+ * Works for ALL templates by detecting label cells heuristically (2-cell table rows
+ * where one cell has no data binding and the adjacent one does).
+ *
+ * Classic Blue special-case: normalizeClassicBlueDetailSections() moves the visible
+ * rows into a .classic-blue-detail-group table tagged with data-detail-source, and
+ * hides the original sections. We must apply label changes to those rows too.
+ */
+function applySectionLabels(sectionLabels) {
+    const LABEL_SECTIONS = ['certifications', 'interests', 'skills', 'achievements', 'leadership'];
+
+    // Helper: apply text + visibility to a single 2-cell table/div row
+    function applyToRow(row, customText, visible) {
+        let cells;
+        if (row.tagName === 'TR') {
+            cells = Array.from(row.children).filter(el => /^(TD|TH)$/i.test(el.tagName));
+        } else {
+            // For div-based rows (like Serif Split)
+            cells = Array.from(row.children).filter(el => /^(DIV|TD|TH)$/i.test(el.tagName) && !el.classList.contains('template'));
+        }
+        if (cells.length !== 2) return;
+
+        const [first, second] = cells;
+        const firstHasBinding = !!(first.querySelector('[data-list], [data-field]'));
+        const secondHasBinding = !!(second.querySelector('[data-list], [data-field]'));
+
+        let labelCell, contentCell;
+        if (!firstHasBinding && secondHasBinding) {
+            labelCell = first;
+            contentCell = second;
+        } else if (firstHasBinding && !secondHasBinding) {
+            labelCell = second;
+            contentCell = first;
+        } else {
+            return; // Both or neither have bindings — skip
+        }
+
+        // Apply custom text if provided
+        if (customText !== null && customText !== '') {
+            const currentText = (labelCell.textContent || '').trim();
+            if (currentText !== customText) {
+                labelCell.textContent = customText;
+            }
+        }
+
+        // Toggle label visibility
+        if (!visible) {
+            labelCell.style.display = 'none';
+            contentCell.setAttribute('colspan', '2');
+            contentCell.style.setProperty('width', '100%', 'important');
+        } else {
+            labelCell.style.display = '';
+            contentCell.removeAttribute('colspan');
+            contentCell.style.removeProperty('width');
+        }
+    }
+
+    // Classic Blue groups certifications/interests/skills/achievements/leadership
+    // into a single table with rows tagged data-detail-source="sectionId".
+    // These are the VISIBLE rows; the original sections are hidden.
+    const classicBlueGroup = document.querySelector('.sortable-section.classic-blue-detail-group');
+
+    // Combine built-in sections + any custom section IDs that have label config
+    const customSectionIds = Object.keys(sectionLabels).filter(id => !LABEL_SECTIONS.includes(id));
+
+    // --- Process built-in label sections ---
+    LABEL_SECTIONS.forEach(sectionId => {
+        const config = sectionLabels[sectionId];
+        const customText = config?.text || null;
+        const visible = config?.visible !== false; // default visible
+
+        // --- Pass 1: Classic Blue detail group rows (visible in Classic Blue) ---
+        if (classicBlueGroup) {
+            const detailRow = classicBlueGroup.querySelector(`tr[data-detail-source="${sectionId}"]`);
+            if (detailRow) applyToRow(detailRow, customText, visible);
+        }
+
+        // --- Pass 2: All other templates — look inside the sortable-section wrapper ---
+        // Special case: combined table where sections are inside a single table row rather than separate sortable-sections
+        const combinedBoundEl = document.querySelector(`table[data-preserve-label-columns] [data-field="${sectionId}"], table[data-preserve-label-columns] [data-list="${sectionId}"]`);
+        if (combinedBoundEl) {
+            const combinedRow = combinedBoundEl.closest('tr');
+            if (combinedRow) {
+                applyToRow(combinedRow, customText, visible);
+                return;
+            }
+        }
+
+        const section = document.querySelector(`.sortable-section[data-section-id="${sectionId}"]`);
+        if (!section) return;
+        // Skip the section if it is hidden (Classic Blue hides originals after grouping)
+        if (section.style.display === 'none') return;
+
+        const rows = section.querySelectorAll('tr');
+        if (rows.length > 0) {
+            rows.forEach(row => applyToRow(row, customText, visible));
+        } else {
+            // If there are no tr elements, the section container itself acts as the 2-column row (e.g. Serif Split)
+            applyToRow(section, customText, visible);
+        }
+    });
+
+    // --- Process custom section labels ---
+    const LABEL_SELECTORS = ['.category-label', '.skills-col-label', '.work-label', '.col-left', '.details-label', '.section-label', '.category'];
+
+    customSectionIds.forEach(sectionId => {
+        const config = sectionLabels[sectionId];
+        if (!config) return;
+        const customText = config.text || null;
+        const visible = config.visible !== false;
+
+        // Classic Blue: custom section rows are keyed as "custom-{id}" in the detail group
+        if (classicBlueGroup) {
+            const detailRow = classicBlueGroup.querySelector(`tr[data-detail-source="custom-${sectionId}"]`);
+            if (detailRow) applyToRow(detailRow, customText, visible);
+        }
+
+        // Other templates: find the wrapper by data-custom-section-root attribute
+        const wrapper = document.querySelector(`[data-custom-section-root="${sectionId}"]`);
+        if (!wrapper || wrapper.style.display === 'none') return;
+
+        // Find label element using the same selectors as setSectionBodyLabel
+        let labelEl = null;
+        for (const sel of LABEL_SELECTORS) {
+            labelEl = wrapper.querySelector(sel);
+            if (labelEl) break;
+        }
+        if (!labelEl) return;
+
+        // Apply custom text
+        if (customText !== null && customText !== '') {
+            labelEl.textContent = customText;
+        }
+
+        // Toggle visibility
+        if (!visible) {
+            labelEl.style.display = 'none';
+            // Try to expand the sibling content cell
+            const contentEl = labelEl.nextElementSibling || labelEl.parentElement?.querySelector('[data-list]')?.closest('td, .section-content');
+            if (contentEl) {
+                if (contentEl.tagName === 'TD' || contentEl.tagName === 'TH') {
+                    contentEl.setAttribute('colspan', '2');
+                    contentEl.style.setProperty('width', '100%', 'important');
+                }
+            }
+        } else {
+            labelEl.style.display = '';
+            const contentEl = labelEl.nextElementSibling;
+            if (contentEl) {
+                contentEl.removeAttribute('colspan');
+                contentEl.style.removeProperty('width');
+            }
+        }
+    });
+}
+
+
+
 
 function applyEducationTableFormat(columns) {
     const section = document.querySelector('.sortable-section[data-section-id="education"]');

--- a/cv-builder/cv-script.js
+++ b/cv-builder/cv-script.js
@@ -62,7 +62,8 @@
             themeAccent: "",
             customSections: [],
             sectionOrder: [...BASE_SECTION_ORDER],
-            tableSettings: getDefaultTableSettings()
+            tableSettings: getDefaultTableSettings(),
+            sectionLabels: {}
         };
         
         const DEMO_PREVIEW_DATA = {
@@ -1192,6 +1193,7 @@
                 };
             });
             ensureTableSettingsShape();
+            ensureSectionLabelsShape();
         }
 
         function ensureTableSettingsShape() {
@@ -1226,6 +1228,114 @@
         function getEducationTableSettings() {
             ensureCvDataShape();
             return cvData.tableSettings.education.columns;
+        }
+
+        // --- Section Label Defaults ---
+        const SECTION_LABEL_DEFAULTS = {
+            certifications: 'Certifications',
+            interests: 'Interests',
+            skills: 'Skills',
+            achievements: 'Highlights',
+            leadership: 'Responsibility'
+        };
+
+        function ensureSectionLabelsShape() {
+            if (!cvData.sectionLabels || typeof cvData.sectionLabels !== 'object') {
+                cvData.sectionLabels = {};
+            }
+            Object.keys(SECTION_LABEL_DEFAULTS).forEach(key => {
+                if (!cvData.sectionLabels[key] || typeof cvData.sectionLabels[key] !== 'object') {
+                    cvData.sectionLabels[key] = { text: SECTION_LABEL_DEFAULTS[key], visible: true };
+                }
+                if (typeof cvData.sectionLabels[key].text !== 'string') {
+                    cvData.sectionLabels[key].text = SECTION_LABEL_DEFAULTS[key];
+                }
+                if (typeof cvData.sectionLabels[key].visible !== 'boolean') {
+                    cvData.sectionLabels[key].visible = true;
+                }
+            });
+        }
+
+        function updateSectionLabel(sectionId, field, value) {
+            ensureSectionLabelsShape();
+            // Auto-initialize label entry for custom sections (not pre-seeded by ensureSectionLabelsShape)
+            if (!cvData.sectionLabels[sectionId]) {
+                const customSection = (cvData.customSections || []).find(s => s.id === sectionId);
+                if (customSection) {
+                    cvData.sectionLabels[sectionId] = { text: customSection.title || '', visible: true };
+                } else {
+                    return;
+                }
+            }
+            if (field === 'visible') {
+                cvData.sectionLabels[sectionId].visible = !!value;
+            } else if (field === 'text') {
+                cvData.sectionLabels[sectionId].text = String(value || '');
+            }
+            postToFrame();
+            // Sync the panel UI for this section
+            const panelId = `section-label-panel-${sectionId}`;
+            const panel = document.getElementById(panelId);
+            if (panel && panel.classList.contains('open')) {
+                // Refresh the input values without closing
+                const textInput = panel.querySelector('.section-label-text-input');
+                const checkbox = panel.querySelector('.section-label-visible-check');
+                const config = cvData.sectionLabels[sectionId];
+                if (textInput && field !== 'text') textInput.value = config.text;
+                if (checkbox && field !== 'visible') checkbox.checked = config.visible;
+            }
+        }
+
+        function toggleSectionLabelPanel(sectionId, event) {
+            if (event) { event.preventDefault(); event.stopPropagation(); }
+            const panelId = `section-label-panel-${sectionId}`;
+            const panel = document.getElementById(panelId);
+            if (!panel) return;
+            const shouldOpen = !panel.classList.contains('open');
+            panel.classList.toggle('open', shouldOpen);
+            panel.setAttribute('aria-hidden', shouldOpen ? 'false' : 'true');
+            if (shouldOpen) renderSectionLabelPanel(sectionId);
+        }
+
+        function renderSectionLabelPanel(sectionId) {
+            ensureSectionLabelsShape();
+            const panelId = `section-label-panel-${sectionId}`;
+            const panel = document.getElementById(panelId);
+            if (!panel) return;
+            const customSectionDefault = (cvData.customSections || []).find(s => s.id === sectionId);
+            const config = cvData.sectionLabels[sectionId] || { text: SECTION_LABEL_DEFAULTS[sectionId] || (customSectionDefault ? customSectionDefault.title || '' : ''), visible: true };
+            panel.innerHTML = `
+                <div class="table-format-panel-head">
+                    <div>
+                        <div class="table-format-title">Section Label</div>
+                        <div class="table-format-subtitle">Rename or hide the grey left-label column.</div>
+                    </div>
+                    <button class="btn-mini" type="button" onclick="resetSectionLabel('${sectionId}')">Reset</button>
+                </div>
+                <div style="display:flex; gap:10px; align-items:center; flex-wrap:wrap;">
+                    <input type="text" class="form-control section-label-text-input" style="flex:1; min-width:120px;"
+                        value="${(config.text || '').replace(/"/g, '&quot;')}"
+                        placeholder="e.g. Certifications"
+                        oninput="updateSectionLabel('${sectionId}', 'text', this.value)">
+                    <label style="display:flex; align-items:center; gap:6px; font-size:13px; font-weight:600; white-space:nowrap; cursor:pointer;">
+                        <input type="checkbox" class="section-label-visible-check" ${config.visible ? 'checked' : ''}
+                            onchange="updateSectionLabel('${sectionId}', 'visible', this.checked)">
+                        Show label
+                    </label>
+                </div>
+            `;
+        }
+
+        function resetSectionLabel(sectionId) {
+            ensureSectionLabelsShape();
+            if (cvData.sectionLabels[sectionId]) {
+                // For custom sections, reset text to the section's own title
+                const customSection = (cvData.customSections || []).find(s => s.id === sectionId);
+                cvData.sectionLabels[sectionId].text = SECTION_LABEL_DEFAULTS[sectionId] || (customSection ? customSection.title || '' : '');
+                cvData.sectionLabels[sectionId].visible = true;
+            }
+            renderSectionLabelPanel(sectionId);
+            postToFrame();
         }
 
         function getSelectedTemplateFile() {
@@ -1407,6 +1517,12 @@
             document.getElementById('inp-email').value = cvData.personal.email || '';
             document.getElementById('inp-linkedin').value = cvData.personal.linkedin || '';
             document.getElementById('inp-location').value = cvData.personal.location || '';
+            const h1El = document.getElementById('inp-highlight1');
+            const h2El = document.getElementById('inp-highlight2');
+            const h3El = document.getElementById('inp-highlight3');
+            if (h1El) h1El.value = cvData.personal.highlight1 || '';
+            if (h2El) h2El.value = cvData.personal.highlight2 || '';
+            if (h3El) h3El.value = cvData.personal.highlight3 || '';
             setSummaryEditorValue(cvData.summary || '');
             setSkillsEditorValue(cvData.skills || '');
 
@@ -1426,6 +1542,7 @@
             renderSectionOrderEditor();
             renderEducationFormatControls();
             initSectionInlineRichEditors();
+            updateTemplateSpecificPanels();
         }
 
         function renderEducationFormatControls() {
@@ -1739,6 +1856,9 @@
             cvData.personal.email = document.getElementById('inp-email').value;
             cvData.personal.linkedin = document.getElementById('inp-linkedin').value;
             cvData.personal.location = document.getElementById('inp-location').value;
+            cvData.personal.highlight1 = document.getElementById('inp-highlight1')?.value || '';
+            cvData.personal.highlight2 = document.getElementById('inp-highlight2')?.value || '';
+            cvData.personal.highlight3 = document.getElementById('inp-highlight3')?.value || '';
             cvData.personal.contact = '';
             if (summaryQuill) {
                 syncSummaryFromEditor();
@@ -2027,8 +2147,13 @@
                 details.open = true;
                 details.setAttribute('data-section', section.id || '');
                 details.innerHTML = `
-                    <summary>${section.title || 'Custom Section'}</summary>
+                    <summary>
+                        <span>${section.title || 'Custom Section'}</span>
+                        <button class="chip" type="button" onclick="toggleSectionLabelPanel('${section.id}', event)"
+                            style="font-size:10px; padding:4px 8px;">Label</button>
+                    </summary>
                     <div class="section-body">
+                        <div id="section-label-panel-${section.id}" class="table-format-panel-wrap" aria-hidden="true"></div>
                         <div class="form-group">
                             <label>Section Title</label>
                             <input type="text" class="form-control" value="${section.title || ''}"
@@ -2588,10 +2713,17 @@
             updateUndoRedoControls();
         }
 
+        function updateTemplateSpecificPanels() {
+            const file = getSelectedTemplateFile();
+            const panel = document.getElementById('highlights-panel');
+            if (panel) panel.style.display = file === 'monochrome-ledger.html' ? '' : 'none';
+        }
+
         function changeTemplate(options = {}) {
             const select = document.getElementById('template-select');
             const frame = document.getElementById('cv-frame');
             const skipHistory = !!options.skipHistory;
+            updateTemplateSpecificPanels();
 
             document.querySelector('.loading-overlay').classList.add('active');
             frame.src = select.value;

--- a/cv-builder/executive-dark.html
+++ b/cv-builder/executive-dark.html
@@ -9,9 +9,9 @@
            CORE VARIABLES & RESET
            --------------------------------------------------------- */
         :root {
-            --header-bg: #404040;
-            --section-bg: #999999;
-            --table-header-bg: #D9D9D9;
+            --header-bg: var(--header-bg-dark, #404040);
+            --section-bg: var(--accent-color, #999999);
+            --table-header-bg: var(--sub-header-bg, #D9D9D9);
             --cell-bg-grey: #E6E6E6;
             --border-color: #000000;
             --text-black: #000000;
@@ -176,7 +176,7 @@
         
         .exp-col-role {
             width: 18%;
-            background-color: #D9D9D9;
+            background-color: var(--table-header-bg);
             vertical-align: middle;
             text-align: center;
             font-weight: bold;
@@ -204,7 +204,7 @@
         /* SKILLS TABLE */
         .skills-col-label {
             width: 18%;
-            background-color: #D9D9D9;
+            background-color: var(--table-header-bg);
             font-weight: bold;
             text-align: center;
             vertical-align: middle;

--- a/cv-builder/index.html
+++ b/cv-builder/index.html
@@ -204,6 +204,25 @@
                 </div>
             </details>
 
+            <details id="highlights-panel" style="display:none">
+                <summary>Highlight Banners</summary>
+                <div class="section-body">
+                    <p style="font-size:12px;color:#888;margin-bottom:10px;">These 3 banners appear at the top of the Monochrome Ledger template.</p>
+                    <div class="form-group">
+                        <label>Banner 1</label>
+                        <input type="text" class="form-control" id="inp-highlight1" placeholder="e.g. Top Academic Performer" oninput="updateCV()">
+                    </div>
+                    <div class="form-group">
+                        <label>Banner 2</label>
+                        <input type="text" class="form-control" id="inp-highlight2" placeholder="e.g. Article Trainee Experience" oninput="updateCV()">
+                    </div>
+                    <div class="form-group">
+                        <label>Banner 3</label>
+                        <input type="text" class="form-control" id="inp-highlight3" placeholder="e.g. Leadership & Awards" oninput="updateCV()">
+                    </div>
+                </div>
+            </details>
+
             <details data-section="summary">
                 <summary>Career Objective</summary>
                 <div class="section-body">
@@ -303,8 +322,13 @@
             </details>
 
             <details data-section="certifications">
-                <summary>Certifications</summary>
+                <summary>
+                    <span>Certifications</span>
+                    <button class="chip" type="button" onclick="toggleSectionLabelPanel('certifications', event)"
+                        style="font-size:10px; padding:4px 8px;">Label</button>
+                </summary>
                 <div class="section-body">
+                    <div id="section-label-panel-certifications" class="table-format-panel-wrap" aria-hidden="true"></div>
                     <div id="cert-container"></div>
                     <button class="btn-dashed" onclick="addCertification()">
                         <svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2"
@@ -318,8 +342,13 @@
             </details>
 
             <details data-section="achievements">
-                <summary>Achievements & Awards</summary>
+                <summary>
+                    <span>Achievements &amp; Awards</span>
+                    <button class="chip" type="button" onclick="toggleSectionLabelPanel('achievements', event)"
+                        style="font-size:10px; padding:4px 8px;">Label</button>
+                </summary>
                 <div class="section-body">
+                    <div id="section-label-panel-achievements" class="table-format-panel-wrap" aria-hidden="true"></div>
                     <div class="form-group">
                         <div style="display:flex; align-items:center; justify-content:space-between; margin-bottom:6px;">
                             <label style="margin-bottom:0;">Achievements (All)</label>
@@ -344,8 +373,13 @@
             </details>
 
             <details data-section="leadership">
-                <summary>Leadership</summary>
+                <summary>
+                    <span>Leadership</span>
+                    <button class="chip" type="button" onclick="toggleSectionLabelPanel('leadership', event)"
+                        style="font-size:10px; padding:4px 8px;">Label</button>
+                </summary>
                 <div class="section-body">
+                    <div id="section-label-panel-leadership" class="table-format-panel-wrap" aria-hidden="true"></div>
                     <div class="form-group">
                         <div style="display:flex; align-items:center; justify-content:space-between; margin-bottom:6px;">
                             <label style="margin-bottom:0;">Leadership (All)</label>
@@ -370,8 +404,13 @@
             </details>
 
             <details data-section="interests">
-                <summary>Interests & Hobbies</summary>
+                <summary>
+                    <span>Interests &amp; Hobbies</span>
+                    <button class="chip" type="button" onclick="toggleSectionLabelPanel('interests', event)"
+                        style="font-size:10px; padding:4px 8px;">Label</button>
+                </summary>
                 <div class="section-body">
+                    <div id="section-label-panel-interests" class="table-format-panel-wrap" aria-hidden="true"></div>
                     <div class="form-group">
                         <div style="display:flex; align-items:center; justify-content:space-between; margin-bottom:6px;">
                             <label style="margin-bottom:0;">Interests (All)</label>
@@ -396,8 +435,13 @@
             </details>
 
             <details data-section="skills">
-                <summary>Skills</summary>
+                <summary>
+                    <span>Skills</span>
+                    <button class="chip" type="button" onclick="toggleSectionLabelPanel('skills', event)"
+                        style="font-size:10px; padding:4px 8px;">Label</button>
+                </summary>
                 <div class="section-body">
+                    <div id="section-label-panel-skills" class="table-format-panel-wrap" aria-hidden="true"></div>
                     <div class="chip-container" id="skills-chips"></div>
                     <div class="form-group">
                         <div

--- a/cv-builder/monochrome-ledger.html
+++ b/cv-builder/monochrome-ledger.html
@@ -6,9 +6,9 @@
     <title>CV - Template 14</title>
     <style>
         :root {
-            --bg-dark: #000000;
-            --bg-light-grey: #f2f2f2;
-            --border-color: #000000;
+            --bg-dark: var(--accent-color, #000000);
+            --bg-light-grey: var(--sub-bg, #f2f2f2);
+            --border-color: var(--blue-deep, #000000);
             --text-black: #000000;
             --bg-white: #ffffff;
             --font-main: 'Georgia', 'Times New Roman', serif;
@@ -89,7 +89,6 @@
             font-size: calc(44px * var(--content-scale));
             font-weight: 900;
             line-height: 1.1;
-            text-transform: uppercase;
         }
 
         .header-subtitle {
@@ -120,7 +119,7 @@
         }
 
         .highlight-box {
-            background-color: var(--bg-dark);
+            background-color: var(--accent-color, var(--bg-dark));
             color: #ffffff;
             flex: 1;
             text-align: center;
@@ -292,9 +291,9 @@
             </div>
 
             <div class="highlights">
-                <div class="highlight-box">Top Academic Performer</div>
-                <div class="highlight-box">Article Trainee Experience</div>
-                <div class="highlight-box">Leadership & Awards</div>
+                <div class="highlight-box" data-field="highlight1">Top Academic Performer</div>
+                <div class="highlight-box" data-field="highlight2">Article Trainee Experience</div>
+                <div class="highlight-box" data-field="highlight3">Leadership & Awards</div>
             </div>
 
             <div class="section sortable-section" data-section-id="summary">

--- a/cv-builder/navy-merit.html
+++ b/cv-builder/navy-merit.html
@@ -6,8 +6,8 @@
     <title>CV - Template 13</title>
     <style>
         :root {
-            --blue-header: #001f5f;
-            --blue-subheader: #d9e2f3;
+            --blue-header: var(--header-bg, #001f5f);
+            --blue-subheader: var(--sub-header-bg, #d9e2f3);
             --border-color: #000000;
             --text-black: #000000;
             --bg-white: #ffffff;

--- a/cv-builder/navy-professional.html
+++ b/cv-builder/navy-professional.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
 
 <head>
@@ -426,6 +426,13 @@
             content: "\2022\00A0\00A0";
         }
 
+        .skills-table .val li p,
+        .skills-table .val li div {
+            display: inline !important;
+            margin: 0 !important;
+            padding: 0 !important;
+        }
+
         /* Certifications & custom-section bullet lists — val-bullet style matching temp5 */
         .sortable-section[data-section-id="certifications"] ul,
         ul.bullet-list {
@@ -617,7 +624,7 @@
                             </td>
                         </tr>
                         <tr>
-                            <td class="lbl" style="vertical-align:top;">Interests and Hobbies<d>
+                            <td class="lbl" style="vertical-align:top;">Interests and Hobbies</td>
                             <td class="val">
                                 <ul data-list="interests"></ul>
                             </td>
@@ -733,14 +740,6 @@
         function shrinkContentToFit() {
             renderContactNavy();
             renderCertsBold();
-            // Keep the combined Skills/Achievements block directly below Certifications,
-            // regardless of the saved section order.
-            var _page = document.getElementById('cv-page');
-            var _certs = _page && _page.querySelector('.sortable-section[data-section-id="certifications"]');
-            var _skills = _page && _page.querySelector('.sortable-section[data-section-id="skills"]');
-            if (_certs && _skills && _certs.parentElement === _skills.parentElement) {
-                _certs.after(_skills);
-            }
             // Re-apply fixed layout to skills-table — stabilizeSectionLayouts() overrides it with auto
             var st = document.querySelector('.skills-table');
             if (st) st.style.setProperty('table-layout', 'fixed', 'important');

--- a/cv-builder/serif-split-ledger.html
+++ b/cv-builder/serif-split-ledger.html
@@ -506,8 +506,10 @@
             });
 
             const rowsByGroup = new Map();
+            const visibleRowsList = [];
             rows.forEach(row => {
-                if (row.style.display === 'none' || getComputedStyle(row).display === 'none') return;
+                if (row.style.display === 'none') return;
+                visibleRowsList.push(row);
                 const group = row.getAttribute('data-serif-group') || '';
                 if (!rowsByGroup.has(group)) rowsByGroup.set(group, []);
                 rowsByGroup.get(group).push(row);
@@ -516,8 +518,11 @@
             rowsByGroup.forEach(groupRows => {
                 if (!groupRows.length) return;
                 groupRows[0].classList.add('serif-group-start');
-                groupRows[groupRows.length - 1].classList.add('serif-group-last');
             });
+
+            if (visibleRowsList.length > 0) {
+                visibleRowsList[visibleRowsList.length - 1].classList.add('serif-group-last');
+            }
         }
 
         let serifSplitFrame = null;

--- a/cv-builder/slate-split.html
+++ b/cv-builder/slate-split.html
@@ -6,10 +6,10 @@
     <title>CV - Template 15</title>
     <style>
         :root {
-            --bg-header: #28535e;
-            --bg-left: #f2f5f7;
+            --bg-header: var(--header-bg, #28535e);
+            --bg-left: var(--sub-bg, #f2f5f7);
             --text-primary: #1d2a36;
-            --text-heading: #2a4365;
+            --text-heading: var(--blue-text, #2a4365);
             --bg-white: #ffffff;
             --font-name: 'Helvetica Neue', Helvetica, Arial, sans-serif;
             --font-main: 'Georgia', 'Times New Roman', serif;

--- a/cv-builder/steel-blue-grid.html
+++ b/cv-builder/steel-blue-grid.html
@@ -97,7 +97,6 @@
             margin-bottom: calc(2px * var(--content-scale));
             line-height: 1.05;
             text-align: left;
-            text-transform: uppercase;
         }
 
         .subtitle {

--- a/experienced-ca-jobs.html
+++ b/experienced-ca-jobs.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html lang="en">
 
 <head>
@@ -6,8 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>My Student Club - Experienced CA Jobs</title>
     <meta name="description"
-        content="Find the best CA fresher job opportunities at My Student Club's job portal. Launch your career as a qualified Chartered Accountant.">
-    <meta name="keywords" content="CA fresher jobs, chartered accountant jobs, CA career, entry-level CA positions">
+        content="Find the best experienced CA job opportunities at My Student Club's job portal. Advance your career as a qualified Chartered Accountant with 1+ years of experience.">
+    <meta name="keywords" content="experienced CA jobs, chartered accountant jobs, CA career, senior CA positions, post-qualification CA jobs">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700;800&display=swap"
         rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
@@ -407,7 +407,7 @@
                                     points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
                             </svg>
                         </div>
-                        <div style="font-weight: 600; font-size: 0.9rem; color: #1f2937;">CA Fresher (Experienced)</div>
+                        <div style="font-weight: 600; font-size: 0.9rem; color: #1f2937;">Experienced CA</div>
                     </button>
                     <button class="pref-option-btn" data-preference="semi_fresher"
                         style="display: flex; align-items: center; gap: 0.75rem; padding: 0.65rem 0.75rem; border: 2px solid #e5e7eb; border-radius: 10px; background: white; cursor: pointer; transition: all 0.2s; text-align: left;">

--- a/experienced-ca.html
+++ b/experienced-ca.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html lang="en">
 
 <head>
@@ -344,7 +344,7 @@
                   points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
               </svg>
             </div>
-            <div style="font-weight: 600; font-size: 0.9rem; color: #1f2937;">CA Fresher (Experienced)</div>
+            <div style="font-weight: 600; font-size: 0.9rem; color: #1f2937;">Experienced CA</div>
           </button>
           <button class="pref-option-btn" data-preference="semi_fresher"
             style="display: flex; align-items: center; gap: 0.75rem; padding: 0.65rem 0.75rem; border: 2px solid #e5e7eb; border-radius: 10px; background: white; cursor: pointer; transition: all 0.2s; text-align: left;">

--- a/fresher.html
+++ b/fresher.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html lang="en">
 
 <head>
@@ -344,7 +344,7 @@
                   points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
               </svg>
             </div>
-            <div style="font-weight: 600; font-size: 0.9rem; color: #1f2937;">CA Fresher (Experienced)</div>
+            <div style="font-weight: 600; font-size: 0.9rem; color: #1f2937;">Experienced CA</div>
           </button>
           <button class="pref-option-btn" data-preference="semi_fresher"
             style="display: flex; align-items: center; gap: 0.75rem; padding: 0.65rem 0.75rem; border: 2px solid #e5e7eb; border-radius: 10px; background: white; cursor: pointer; transition: all 0.2s; text-align: left;">

--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html lang="en">
 
 <head>
@@ -553,6 +553,9 @@
       <a href="/ca-fresher-jobs" class="footer-tab">
         <span>CA Freshers</span>
       </a>
+      <a href="/experienced-ca-jobs" class="footer-tab">
+        <span>Experienced CA</span>
+      </a>
     </nav>
 
     <div class="job-portal-layout">
@@ -934,7 +937,7 @@
                   points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
               </svg>
             </div>
-            <div style="font-weight: 600; font-size: 0.9rem; color: #1f2937;">CA Fresher (Experienced)</div>
+            <div style="font-weight: 600; font-size: 0.9rem; color: #1f2937;">Experienced CA</div>
           </button>
 
           <button class="pref-option-btn" data-preference="semi_fresher"

--- a/profile.html
+++ b/profile.html
@@ -1414,7 +1414,7 @@
                                         <option value="industrial">Industrial Training</option>
                                         <option value="articleship">Articleship</option>
                                         <option value="fresher_fresher">CA Fresher (Fresher)</option>
-                                        <option value="fresher_experienced">CA Fresher (Experienced)</option>
+                                        <option value="fresher_experienced">Experienced CA</option>
                                         <option value="semi_fresher">Semi Qualified (Fresher)</option>
                                         <option value="semi_experienced">Semi Qualified (Experienced)</option>
                                     </select>

--- a/scripts/profile.js
+++ b/scripts/profile.js
@@ -1,4 +1,4 @@
-const supabaseUrl = 'https://izsggdtdiacxdsjjncdq.supabase.co';
+﻿const supabaseUrl = 'https://izsggdtdiacxdsjjncdq.supabase.co';
 const supabaseKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Iml6c2dnZHRkaWFjeGRzampuY2RxIiwicm9sZSI6ImFub24iLCJpYXQiOjE3Mzg1OTEzNjUsImV4cCI6MjA1NDE2NzM2NX0.FVKBJG-TmXiiYzBDjGIRBM2zg-DYxzNP--WM6q2UMt0';
 const supabaseClient = supabase.createClient(supabaseUrl, supabaseKey);
 pdfjsLib.GlobalWorkerOptions.workerSrc = '/scripts/vendor/pdf.worker.min.js';
@@ -3091,7 +3091,7 @@ function refreshSavedDisplays(d) {
         'industrial': 'MSC Industrial Training Program',
         'articleship': 'Articleship',
         'fresher_fresher': 'CA Fresher (Fresher)',
-        'fresher_experienced': 'CA Fresher (Experienced)',
+        'fresher_experienced': 'Experienced CA',
         'semi_fresher': 'Semi Qualified (Fresher)',
         'semi_experienced': 'Semi Qualified (Experienced)'
     };

--- a/semi-qualified-ca-jobs.html
+++ b/semi-qualified-ca-jobs.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html lang="en">
 
 <head>
@@ -131,6 +131,9 @@
             </a>
             <a href="/ca-fresher-jobs" class="footer-tab">
                 <span>CA Freshers</span>
+            </a>
+            <a href="/experienced-ca-jobs" class="footer-tab">
+                <span>Experienced CA</span>
             </a>
         </nav>
 
@@ -418,7 +421,7 @@
                                     points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
                             </svg>
                         </div>
-                        <div style="font-weight: 600; font-size: 0.9rem; color: #1f2937;">CA Fresher (Experienced)</div>
+                        <div style="font-weight: 600; font-size: 0.9rem; color: #1f2937;">Experienced CA</div>
                     </button>
                     <button class="pref-option-btn" data-preference="semi_fresher"
                         style="display: flex; align-items: center; gap: 0.75rem; padding: 0.65rem 0.75rem; border: 2px solid #e5e7eb; border-radius: 10px; background: white; cursor: pointer; transition: all 0.2s; text-align: left;">

--- a/semi-qualified.html
+++ b/semi-qualified.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html lang="en">
 
 <head>
@@ -358,7 +358,7 @@
                   points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
               </svg>
             </div>
-            <div style="font-weight: 600; font-size: 0.9rem; color: #1f2937;">CA Fresher (Experienced)</div>
+            <div style="font-weight: 600; font-size: 0.9rem; color: #1f2937;">Experienced CA</div>
           </button>
           <button class="pref-option-btn" data-preference="semi_fresher"
             style="display: flex; align-items: center; gap: 0.75rem; padding: 0.65rem 0.75rem; border: 2px solid #e5e7eb; border-radius: 10px; background: white; cursor: pointer; transition: all 0.2s; text-align: left;">


### PR DESCRIPTION
# Pull Request: CV Builder Enhancements & Bug Fixes & Experienced CA portal

This Pull Request incorporates feature additions for the Monochrome Ledger template, configurable section labels, git merge conflict resolution, and key rendering/ordering bug fixes for the Navy Professional template.Also implements 5th portal which is experienced CA jobs portal in the main page.

---

## 🚀 Features

### 1. Highlight Banners for Monochrome Ledger Template
- **UI Panel**: Added a "Highlight Banners" input section in [index.html](file:///d:/Intern/mystudentclub/cv-builder/index.html) (bound to `inp-highlight1`, `inp-highlight2`, and `inp-highlight3`).
- **Dynamic Display**: Configured the panel to show dynamically only when the **Monochrome Ledger** (`monochrome-ledger.html`) template is active.
- **Logic Integration**: Handled standard bindings and input syncing inside [cv-script.js](file:///d:/Intern/mystudentclub/cv-builder/cv-script.js).

### 2. Configurable Section Labels (Rename / Hide)
- **Label Configuration Panel**: Introduced a sub-panel in the editors for Certifications, Achievements, Leadership, Interests, Skills, and Custom Sections. Users can now:
  - Rename the left-label column text.
  - Show/hide the label column (hiding expands the content column to full width).
- **Core Helpers**: Implemented state management, rendering, and reset logic in [cv-script.js](file:///d:/Intern/mystudentclub/cv-builder/cv-script.js).
- **Template Rendering**: Refactored `applySectionLabels` inside [cv-common.js](file:///d:/Intern/mystudentclub/cv-builder/cv-common.js) to map labels to specific rows in standard or combined tables using data binding.

---

## 🛠️ Bug Fixes

### 3. Git Merge Conflict Resolution in `cv-common.js`
- Resolved the merge conflict arising from the `git stash pop` in `cv-common.js`.
- Merged the stashed category styling logic (handling fluid column expansion when categories are hidden) with the upstream intro rendering logic to prevent ReferenceErrors.

### 4. Navy Professional Template Layout & Formatting Fixes
- **HTML Typo**: Fixed a critical `<d>` syntax error on line 620 in [navy-professional.html](file:///d:/Intern/mystudentclub/cv-builder/navy-professional.html) (changed it to `</td>`). This error previously disrupted the table columns and broke list indentation.
- **Word Sticking & Sub-grids**: Reverted list item layout from `display: flex` to a standard block layout with hanging indent. Forced block elements inside the list (`p`, `div`) to render as `display: inline !important`. This resolves text-wrapping issues, sub-grids formatting, and word spacing collapse around tags (e.g. `<b>`, `<strong>`).
- **Section Reordering**: Removed the hardcoded layout override in the template script that forced the combined `skills` section directly below `certifications`. This restores the editor's drag-and-drop ordering functionality.

---