### PR TITLE
bug-fixes

### DIFF
--- a/cv-builder/cv-script.js
+++ b/cv-builder/cv-script.js
@@ -203,10 +203,6 @@
                 catch (e) { console.error('Load failed', e); }
             }
             ensureCvDataShape();
-            if (!cvData.experience || cvData.experience.length === 0) {
-                const artEntry = buildArticleshipEntryFromProfile();
-                if (artEntry) cvData.experience = [artEntry];
-            }
             normalizeSectionOrder();
             loadHistory();
 
@@ -2732,74 +2728,7 @@
             renderReorderDrawer();
         }
 
-        function prefillCAEducation(e) {
-            e.stopPropagation();
-            if (confirm("Replace current education with CA path?")) {
-                cvData.education = [
-                    { degree: "CA Final", institute: "ICAI", year: "", marks: "", remarks: "" },
-                    { degree: "CA Intermediate", institute: "ICAI", year: "", marks: "", remarks: "Both Groups" },
-                    { degree: "B.Com", institute: "", year: "", marks: "", remarks: "" },
-                    { degree: "Class XII", institute: "CBSE", year: "", marks: "", remarks: "" }
-                ];
-                renderEduInputs(); updateCV();
-            }
-        }
 
-        function buildArticleshipEntryFromProfile() {
-            const raw = localStorage.getItem('userProfileData');
-            if (!raw) return null;
-            let p;
-            try { p = JSON.parse(raw); } catch(e) { return null; }
-
-            const firmName = (p.articleship_firm_name || '').trim();
-            const firmType = (p.articleship_firm_type || '').trim();
-            if (!firmName && (!firmType || firmType === 'None')) return null;
-
-            const domain = (p.articleship_domain || '').trim();
-            const startMonth = (p.articleship_start_month || '').trim();
-            const startYear = String(p.articleship_start_year || '').trim();
-            const endMonth = (p.articleship_end_month || '').trim();
-            const endYear = String(p.articleship_end_year || '').trim();
-            const responsibilities = (p.articleship_responsibilities || '').trim();
-
-            const startPart = [startMonth, startYear].filter(Boolean).join(' ');
-            const endPart = endYear ? [endMonth, endYear].filter(Boolean).join(' ') : 'Present';
-            const dates = startPart ? `${startPart} – ${endPart}` : '';
-
-            const company = [firmName, firmType && firmType !== 'None' ? firmType : ''].filter(Boolean).join(' | ');
-
-            const bullets = responsibilities
-                ? responsibilities.split('\n')
-                    .map(line => line.replace(/^[\s\-•●*]+/, '').trim())
-                    .filter(Boolean)
-                    .map(line => normalizeImportedRichText(line, 'experience'))
-                : [];
-
-            return {
-                role: 'Article Assistant',
-                company,
-                dates,
-                intro: '',
-                category: domain,
-                bullets,
-                mergedWithPrevious: false,
-                titleMergedWithPrevious: false
-            };
-        }
-
-        function importArticleshipFromProfile(e) {
-            if (e) e.stopPropagation();
-            const entry = buildArticleshipEntryFromProfile();
-            if (!entry) {
-                alert('No articleship data found in your profile. Please fill in the Articleship Experience section on your profile page first.');
-                return;
-            }
-            if (cvData.experience.length > 0 && !confirm('This will replace your current experience entries with your profile articleship data. Continue?')) return;
-            cvData.experience = [entry];
-            normalizeExperienceMerges();
-            renderExpInputs();
-            postToFrame();
-        }
 
         // Core Utilities
         /**

--- a/cv-builder/index.html
+++ b/cv-builder/index.html
@@ -257,8 +257,6 @@
             <details open data-section="experience">
                 <summary>
                     <span>Education</span>
-                    <button class="chip" onclick="prefillCAEducation(event)"
-                        style="font-size:10px; padding:4px 8px;">Auto-fill CA Path</button>
                     <button class="chip" type="button" onclick="toggleEducationFormatPanel(event)"
                         style="font-size:10px; padding:4px 8px;">Table format</button>
                 </summary>
@@ -288,8 +286,6 @@
             <details open>
                 <summary>
                     <span>Experience / Articleship</span>
-                    <button class="chip" onclick="importArticleshipFromProfile(event)"
-                        style="font-size:10px; padding:4px 8px;">From Profile</button>
                 </summary>
                 <div class="section-body">
                     <div id="exp-container"></div>


### PR DESCRIPTION
# PR: Remove "Auto-fill CA Path" and "From Profile" buttons from CV Builder

## Description & Rationale

This PR removes the **"Auto-fill CA Path"** (Education section) and **"From Profile"** (Experience / Articleship section) action buttons and their underlying JavaScript logic from the CV Builder.

### Problem Addressed
* **Data Loss / Unintended Overwrites**: Clicking "Auto-fill CA Path" replaced the entire existing Education section with generic, incomplete template rows (where `year`, `marks`, and institute details were blank), inadvertently wiping out user-entered education details.
* **Redundant / Destructive Import**: "From Profile" similarly replaced all custom experience entries with profile articleship data upon confirmation.

## Summary of Changes

### 1. Frontend Template (`cv-builder/index.html`)
- Removed the `<button class="chip" onclick="prefillCAEducation(event)">Auto-fill CA Path</button>` button from the Education section header.
- Removed the `<button class="chip" onclick="importArticleshipFromProfile(event)">From Profile</button>` button from the Experience / Articleship section header.

### 2. Client Scripts (`cv-builder/cv-script.js`)
- Removed `prefillCAEducation()` function which overwrote `cvData.education` with hardcoded CA template rows.
- Removed `importArticleshipFromProfile()` function which imported profile data into `cvData.experience`.
- Removed `buildArticleshipEntryFromProfile()` helper function.
- Removed automatic initial loading of profile articleship data into `cvData.experience` when experience array was empty.

## Verification & Testing
- Verified that Education and Experience section headers render cleanly without orphan buttons.
- Confirmed no JavaScript errors or dead references exist in `cv-script.js`.
