### PR TITLE
feat(cv-builder): add typography font picker, color dropdowns, and se…

### DIFF
--- a/cv-builder/cv-common.js
+++ b/cv-builder/cv-common.js
@@ -45,6 +45,7 @@ function renderCV(data) {
     ensureUniversalSections();
     ensureSectionWrappers();
     applyTemplateAccent(data.themeAccent || '');
+    applyTemplateFont(data.themeFont || '');
     syncDocumentTitle(data);
 
     // 1. Personal Info
@@ -301,21 +302,29 @@ function renderCV(data) {
             const host = ensureFieldHostSupportsRichContent(descSpan, normalized);
             host.innerHTML = normalized;
 
-            // Find the parent TD containing the description
+            // If description is empty, hide its host element
+            const descEmpty = !stripTags(descriptionText).trim();
+            host.style.display = descEmpty ? 'none' : '';
+
+            // Find the parent TD containing the description if description is in its own column
             const descCell = host.closest('td');
             if (descCell) {
-                const descEmpty = !stripTags(descriptionText).trim();
-                descCell.style.display = descEmpty ? 'none' : '';
-                
-                const bulletsCell = descCell.nextElementSibling;
-                if (bulletsCell && /^TD$/i.test(bulletsCell.tagName || '')) {
-                    if (descEmpty) {
-                        bulletsCell.setAttribute('colspan', '2');
-                        bulletsCell.style.setProperty('width', '100%', 'important');
-                    } else {
-                        bulletsCell.removeAttribute('colspan');
-                        bulletsCell.style.removeProperty('width');
+                const ulInSameCell = descCell.querySelector('[data-list="bullets"]');
+                if (!ulInSameCell) {
+                    descCell.style.display = descEmpty ? 'none' : '';
+                    
+                    const bulletsCell = descCell.nextElementSibling;
+                    if (bulletsCell && /^TD$/i.test(bulletsCell.tagName || '')) {
+                        if (descEmpty) {
+                            bulletsCell.setAttribute('colspan', '2');
+                            bulletsCell.style.setProperty('width', '100%', 'important');
+                        } else {
+                            bulletsCell.removeAttribute('colspan');
+                            bulletsCell.style.removeProperty('width');
+                        }
                     }
+                } else {
+                    descCell.style.display = '';
                 }
             }
         }
@@ -392,11 +401,16 @@ function renderCV(data) {
     // 12. Configurable section labels (rename / hide the grey left-label cells)
     applySectionLabels(data.sectionLabels || {});
 
-    // 12. Recalculate Layout (Scale/Shrink)
+    // 13. Configurable section titles (rename section headings, or fall back to template default)
+    applySectionTitles(data.sectionTitles || {});
+
+    // 14. Recalculate Layout (Scale/Shrink)
     // These functions exist in the templates script block
     // Use requestAnimationFrame to ensure DOM is fully updated before recalculating
     requestAnimationFrame(() => {
+        applySectionTitles(data.sectionTitles || {});
         applyTemplateAccent(data.themeAccent || '');
+        applyTemplateFont(data.themeFont || '');
         if (typeof window.shrinkContentToFit === 'function') {
             window.shrinkContentToFit();
         }
@@ -836,8 +850,90 @@ function applySectionLabels(sectionLabels) {
     });
 }
 
+function applySectionTitles(sectionTitles) {
+    const titles = (sectionTitles && typeof sectionTitles === 'object') ? sectionTitles : {};
+    const SECTION_IDS = ['summary', 'education', 'experience', 'projects', 'certifications', 'achievements', 'leadership', 'interests', 'skills'];
 
+    const TITLE_SELECTORS = [
+        '.section-header-title',
+        '.right-title-text',
+        '.section-banner-row td',
+        '.banner-row td',
+        '.section-banner',
+        '.section-header p span',
+        '.section-header p',
+        '.section-header',
+        '.section-header-2',
+        '.section-title',
+        '.pill-banner',
+        '.gray-bar',
+        '.sec-head',
+        '.sec-title',
+        '.heading',
+        '.section-heading',
+        'h2',
+        'h3'
+    ];
 
+    const IGNORE_CONTAINERS = '#experience-list, #education-list, #projects-list, #social-links-container, .experience-item, .job-group, .education-item, .project-item, .list-item, tbody[id], .sub-header-row, .sub-header-cell, .sub-header-content, .sub-section-header, .exp-category, .category-cell';
+
+    SECTION_IDS.forEach(sectionId => {
+        const customTitle = (titles[sectionId] || '').trim();
+        const section = document.querySelector(`.sortable-section[data-section-id="${sectionId}"]`);
+        if (!section) return;
+
+        let titleEl = null;
+        for (const selector of TITLE_SELECTORS) {
+            const elements = section.querySelectorAll(selector);
+            for (const el of elements) {
+                if (!el.closest(IGNORE_CONTAINERS)) {
+                    titleEl = el;
+                    break;
+                }
+            }
+            if (titleEl) break;
+        }
+
+        if (!titleEl) return;
+
+        if (!titleEl.hasAttribute('data-default-title')) {
+            titleEl.setAttribute('data-default-title', titleEl.textContent.trim());
+        }
+
+        const defaultTitle = titleEl.getAttribute('data-default-title') || '';
+        const targetTitle = customTitle || defaultTitle;
+
+        if (titleEl.textContent.trim() !== targetTitle) {
+            titleEl.textContent = targetTitle;
+        }
+    });
+
+    // Custom sections
+    const customSections = window.__currentCVData?.customSections || [];
+    customSections.forEach(cs => {
+        if (!cs || !cs.id) return;
+        const customTitle = (titles[cs.id] !== undefined ? titles[cs.id] : (cs.title || '')).trim();
+        const section = document.querySelector(`[data-custom-section-root="${cs.id}"], .sortable-section[data-section-id="${cs.id}"]`);
+        if (!section) return;
+        let titleEl = null;
+        for (const selector of TITLE_SELECTORS) {
+            const elements = section.querySelectorAll(selector);
+            for (const el of elements) {
+                if (!el.closest(IGNORE_CONTAINERS)) {
+                    titleEl = el;
+                    break;
+                }
+            }
+            if (titleEl) break;
+        }
+        if (titleEl && customTitle) {
+            if (!titleEl.hasAttribute('data-default-title')) {
+                titleEl.setAttribute('data-default-title', titleEl.textContent.trim());
+            }
+            titleEl.textContent = customTitle;
+        }
+    });
+}
 
 function applyEducationTableFormat(columns) {
     const section = document.querySelector('.sortable-section[data-section-id="education"]');
@@ -1097,6 +1193,189 @@ function clearInlineStyles(selector, keys) {
     });
 }
 
+const CV_FONT_CONFIGS = {
+    'calibri': {
+        name: 'Calibri',
+        cssFamily: "Calibri, 'Segoe UI', Arial, sans-serif"
+    },
+    'cambria': {
+        name: 'Cambria',
+        cssFamily: "Cambria, Georgia, 'Times New Roman', serif"
+    },
+    'times': {
+        name: 'Times New Roman',
+        cssFamily: "'Times New Roman', Times, serif"
+    },
+    'times new roman': {
+        name: 'Times New Roman',
+        cssFamily: "'Times New Roman', Times, serif"
+    },
+    'georgia': {
+        name: 'Georgia',
+        cssFamily: "Georgia, 'Times New Roman', serif"
+    },
+    'garamond': {
+        name: 'Garamond',
+        cssFamily: "Garamond, 'EB Garamond', Georgia, serif",
+        googleFont: 'EB+Garamond:wght@400;600;700'
+    },
+    'eb garamond': {
+        name: 'Garamond',
+        cssFamily: "Garamond, 'EB Garamond', Georgia, serif",
+        googleFont: 'EB+Garamond:wght@400;600;700'
+    },
+    'arial': {
+        name: 'Arial',
+        cssFamily: "Arial, Helvetica, sans-serif"
+    },
+    'inter': {
+        name: 'Inter',
+        cssFamily: "'Inter', sans-serif",
+        googleFont: 'Inter:wght@400;500;600;700'
+    },
+    'roboto': {
+        name: 'Roboto',
+        cssFamily: "'Roboto', sans-serif",
+        googleFont: 'Roboto:wght@400;500;700'
+    },
+    'open sans': {
+        name: 'Open Sans',
+        cssFamily: "'Open Sans', sans-serif",
+        googleFont: 'Open+Sans:wght@400;600;700'
+    },
+    'lato': {
+        name: 'Lato',
+        cssFamily: "'Lato', sans-serif",
+        googleFont: 'Lato:wght@400;700'
+    },
+    'montserrat': {
+        name: 'Montserrat',
+        cssFamily: "'Montserrat', sans-serif",
+        googleFont: 'Montserrat:wght@400;500;600;700'
+    },
+    'poppins': {
+        name: 'Poppins',
+        cssFamily: "'Poppins', sans-serif",
+        googleFont: 'Poppins:wght@400;500;600;700'
+    },
+    'outfit': {
+        name: 'Outfit',
+        cssFamily: "'Outfit', sans-serif",
+        googleFont: 'Outfit:wght@400;500;600;700'
+    },
+    'nunito': {
+        name: 'Nunito',
+        cssFamily: "'Nunito', sans-serif",
+        googleFont: 'Nunito:wght@400;600;700'
+    },
+    'raleway': {
+        name: 'Raleway',
+        cssFamily: "'Raleway', sans-serif",
+        googleFont: 'Raleway:wght@400;500;600;700'
+    },
+    'trebuchet': {
+        name: 'Trebuchet MS',
+        cssFamily: "'Trebuchet MS', 'Lucida Sans', sans-serif"
+    },
+    'trebuchet ms': {
+        name: 'Trebuchet MS',
+        cssFamily: "'Trebuchet MS', 'Lucida Sans', sans-serif"
+    },
+    'century gothic': {
+        name: 'Century Gothic',
+        cssFamily: "'Century Gothic', Arial, sans-serif"
+    },
+    'merriweather': {
+        name: 'Merriweather',
+        cssFamily: "'Merriweather', serif",
+        googleFont: 'Merriweather:wght@400;700'
+    },
+    'playfair display': {
+        name: 'Playfair Display',
+        cssFamily: "'Playfair Display', Georgia, serif",
+        googleFont: 'Playfair+Display:wght@400;600;700'
+    },
+    'lora': {
+        name: 'Lora',
+        cssFamily: "'Lora', Georgia, serif",
+        googleFont: 'Lora:wght@400;500;600'
+    },
+    'libre baskerville': {
+        name: 'Libre Baskerville',
+        cssFamily: "'Libre Baskerville', Georgia, serif",
+        googleFont: 'Libre+Baskerville:wght@400;700'
+    },
+    'pt serif': {
+        name: 'PT Serif',
+        cssFamily: "'PT Serif', Georgia, serif",
+        googleFont: 'PT+Serif:wght@400;700'
+    },
+    'palatino': {
+        name: 'Palatino',
+        cssFamily: "'Palatino Linotype', 'Book Antiqua', Palatino, serif"
+    },
+    'cinzel': {
+        name: 'Cinzel',
+        cssFamily: "'Cinzel', Georgia, serif",
+        googleFont: 'Cinzel:wght@400;600;700'
+    }
+};
+
+function ensureGoogleFontLoaded(fontQuery) {
+    if (!fontQuery) return;
+    const linkId = 'cv-google-font-' + fontQuery.replace(/[^a-zA-Z0-9]/g, '-');
+    if (document.getElementById(linkId)) return;
+    const link = document.createElement('link');
+    link.id = linkId;
+    link.rel = 'stylesheet';
+    link.href = 'https://fonts.googleapis.com/css2?family=' + fontQuery + '&display=swap';
+    document.head.appendChild(link);
+}
+
+function applyTemplateFont(fontKey) {
+    const key = String(fontKey || '').trim().toLowerCase();
+    const root = document.documentElement;
+    const page = document.getElementById('cv-page');
+    let customStyle = document.getElementById('cv-custom-font-style');
+
+    if (!key || key === 'default') {
+        if (customStyle) customStyle.remove();
+        if (page) page.style.removeProperty('font-family');
+        ['--font-main', '--font-body', '--font-heading', '--font-serif', '--font-tahoma', '--font-treb', '--font-name']
+            .forEach(name => root && root.style && root.style.removeProperty(name));
+        return;
+    }
+
+    const config = CV_FONT_CONFIGS[key] || { cssFamily: fontKey };
+    if (config.googleFont) {
+        ensureGoogleFontLoaded(config.googleFont);
+    }
+
+    if (!customStyle) {
+        customStyle = document.createElement('style');
+        customStyle.id = 'cv-custom-font-style';
+        document.head.appendChild(customStyle);
+    }
+
+    customStyle.textContent = `
+        #cv-page, #cv-page *:not(.fa):not(.fas):not(.far):not(.fab):not([class*="icon"]):not(svg):not(path) {
+            font-family: ${config.cssFamily} !important;
+        }
+    `;
+
+    if (root && root.style) {
+        ['--font-main', '--font-body', '--font-heading', '--font-serif', '--font-tahoma', '--font-treb', '--font-name']
+            .forEach(name => root.style.setProperty(name, config.cssFamily));
+    }
+
+    if (document.fonts && typeof document.fonts.ready?.then === 'function') {
+        document.fonts.ready.then(() => {
+            if (typeof window.shrinkContentToFit === 'function') window.shrinkContentToFit();
+            if (typeof window.scaleToFit === 'function') window.scaleToFit();
+        });
+    }
+}
+
 function buildRenderedExperience(items) {
     const source = Array.isArray(items) ? items : [];
     const groups = [];
@@ -1232,6 +1511,7 @@ function applyExperienceTitleMergeDisplayV2(block, item) {
         addWrapper(el.closest('.item-date'));
         addWrapper(el.closest('.exp-title'));
         addWrapper(el.closest('.sub-header-cell'));
+        addWrapper(el.closest('.sub-header-row'));
         addWrapper(el.closest('.job-title-row'));
         addWrapper(el.closest('.job-header'));
         addWrapper(el.closest('.exp-header-details'));
@@ -1245,12 +1525,13 @@ function applyExperienceTitleMergeDisplayV2(block, item) {
         addWrapper(el.closest('.exp-subhead-top'));
         addWrapper(el.closest('.exp-company-title'));
         addWrapper(el.closest('.exp-role-title'));
+        addWrapper(el.closest('.exp-titlebar'));
     });
 
     wrappersToToggle.forEach(el => {
         el.style.display = hideTitle ? 'none' : '';
         const row = el.closest('tr');
-        if (row && row !== block && row.querySelector('.sub-header-cell')) {
+        if (row && row !== block && (row.querySelector('.sub-header-cell') || row.querySelector('.exp-titlebar') || row.classList.contains('sub-header-row'))) {
             row.style.display = hideTitle ? 'none' : '';
         }
     });

--- a/cv-builder/cv-script.js
+++ b/cv-builder/cv-script.js
@@ -60,10 +60,12 @@
             leadership: [],
             skills: "",
             themeAccent: "",
+            themeFont: "",
             customSections: [],
             sectionOrder: [...BASE_SECTION_ORDER],
             tableSettings: getDefaultTableSettings(),
             sectionLabels: {},
+            sectionTitles: {},
             sectionGroups: {}
         };
 
@@ -218,6 +220,8 @@
             initializeUndoRedoHistory();
             initUndoRedoShortcuts();
             updateUndoRedoControls();
+            renderFontControls();
+            renderThemeControls();
 
             const frame = document.getElementById('cv-frame');
             if (frame) {
@@ -1344,6 +1348,7 @@
                     leadership: [],
                     skills: "",
                     themeAccent: "",
+                    themeFont: "",
                     customSections: [],
                     sectionOrder: [...BASE_SECTION_ORDER],
                     tableSettings: getDefaultTableSettings(),
@@ -1367,6 +1372,7 @@
             if (typeof cvData.summary !== 'string') cvData.summary = cvData.summary ? String(cvData.summary) : '';
             if (typeof cvData.skills !== 'string') cvData.skills = cvData.skills ? String(cvData.skills) : '';
             if (typeof cvData.themeAccent !== 'string') cvData.themeAccent = '';
+            if (typeof cvData.themeFont !== 'string') cvData.themeFont = '';
             cvData.personal.name = normalizeImportedString(cvData.personal.name || '');
             cvData.personal.tagline = normalizeImportedString(cvData.personal.tagline || '');
             cvData.personal.contact = normalizeImportedString(cvData.personal.contact || '');
@@ -1426,6 +1432,9 @@
                     items: Array.isArray(entry.items) ? entry.items : []
                 };
             });
+            if (!cvData.sectionTitles || typeof cvData.sectionTitles !== 'object') {
+                cvData.sectionTitles = {};
+            }
             ensureTableSettingsShape();
             ensureSectionLabelsShape();
             normalizeSectionGroups();
@@ -1815,6 +1824,11 @@
 
             updateCharCounter('inp-summary', 'summary-counter', 500, getSummaryPlainText().length);
             updateCharCounter('inp-skills', 'skills-counter', 300, getSkillsPlainText().length);
+
+            ['summary', 'education', 'experience', 'projects', 'certifications', 'achievements', 'leadership', 'interests', 'skills'].forEach(id => {
+                const el = document.getElementById(`inp-title-${id}`);
+                if (el) el.value = (cvData.sectionTitles && cvData.sectionTitles[id]) || '';
+            });
 
             renderEduInputs();
             renderExpInputs();
@@ -2550,10 +2564,21 @@
         }
 
         function getSectionLabel(sectionId) {
+            if (cvData.sectionTitles && cvData.sectionTitles[sectionId] && cvData.sectionTitles[sectionId].trim()) {
+                return cvData.sectionTitles[sectionId].trim();
+            }
             if (SECTION_LABELS[sectionId]) return SECTION_LABELS[sectionId];
             const customSection = (cvData.customSections || []).find(section => section.id === sectionId);
             if (customSection) return customSection.title || 'Custom Section';
             return sectionId;
+        }
+
+        function updateSectionTitle(sectionId, value) {
+            if (!cvData.sectionTitles || typeof cvData.sectionTitles !== 'object') cvData.sectionTitles = {};
+            cvData.sectionTitles[sectionId] = String(value || '');
+            saveLocal();
+            renderSectionOrderEditor();
+            postToFrame();
         }
 
         function moveSectionOrder(index, direction) {
@@ -3097,20 +3122,30 @@
             const picker = document.getElementById('theme-accent-picker');
             const text = document.getElementById('theme-accent-value');
             const chip = document.getElementById('theme-accent-chip');
-            if (!swatchHost || !picker || !text) return;
+            const swatchBtn = document.getElementById('current-color-swatch');
+            const colorName = document.getElementById('current-color-name');
 
             const active = getThemeAccent();
-            swatchHost.innerHTML = TEMPLATE_COLOR_PRESETS.map(color => `
-                <button type="button" class="template-theme-swatch ${active === color.toUpperCase() ? 'active' : ''}" style="background:${color}" title="${color}" onclick="updateThemeAccent('${color}')"></button>
-            `).join('');
+            if (swatchHost) {
+                swatchHost.innerHTML = TEMPLATE_COLOR_PRESETS.map(color => `
+                    <button type="button" class="template-theme-swatch ${active === color.toUpperCase() ? 'active' : ''}" style="background:${color}" title="${color}" onclick="updateThemeAccent('${color}')"></button>
+                `).join('');
+            }
 
             const fallbackColor = active || '#2F557F';
-            picker.value = fallbackColor;
-            text.value = active;
+            if (picker) picker.value = fallbackColor;
+            if (text) text.value = active;
             if (chip) {
                 chip.style.color = active || '#64748b';
                 chip.style.borderColor = active ? `${active}33` : '#dbe3ef';
                 chip.style.background = active ? `${active}14` : '#ffffff';
+            }
+            if (swatchBtn) {
+                swatchBtn.style.background = active || '#2F557F';
+                swatchBtn.style.display = active ? 'inline-block' : 'none';
+            }
+            if (colorName) {
+                colorName.textContent = active || 'Default';
             }
         }
 
@@ -3118,6 +3153,7 @@
             const normalized = normalizeHexColor(value);
             if (!normalized) return;
             cvData.themeAccent = normalized;
+            saveLocal();
             renderThemeControls();
             postToFrame();
             renderTemplateCards();
@@ -3133,10 +3169,128 @@
 
         function resetThemeAccent() {
             cvData.themeAccent = '';
+            saveLocal();
             renderThemeControls();
             postToFrame();
             renderTemplateCards();
         }
+
+        let activeFontCategory = 'all';
+
+        const TEMPLATE_FONTS = [
+            { key: '', name: 'Default', category: 'all', family: '', type: 'Template Native', preview: 'Aa Bb Gg 123' },
+            // Modern Sans-Serif
+            { key: 'Calibri', name: 'Calibri', category: 'sans', family: "Calibri, 'Segoe UI', Arial, sans-serif", type: 'Modern Corporate', preview: 'Aa Bb Gg 123' },
+            { key: 'Inter', name: 'Inter', category: 'sans', family: "'Inter', sans-serif", type: 'Contemporary UI', preview: 'Aa Bb Gg 123' },
+            { key: 'Roboto', name: 'Roboto', category: 'sans', family: "'Roboto', sans-serif", type: 'Clean Geometric', preview: 'Aa Bb Gg 123' },
+            { key: 'Open Sans', name: 'Open Sans', category: 'sans', family: "'Open Sans', sans-serif", type: 'Balanced Neutral', preview: 'Aa Bb Gg 123' },
+            { key: 'Lato', name: 'Lato', category: 'sans', family: "'Lato', sans-serif", type: 'Warm Professional', preview: 'Aa Bb Gg 123' },
+            { key: 'Montserrat', name: 'Montserrat', category: 'sans', family: "'Montserrat', sans-serif", type: 'Modern Architectural', preview: 'Aa Bb Gg 123' },
+            { key: 'Poppins', name: 'Poppins', category: 'sans', family: "'Poppins', sans-serif", type: 'Geometric Clean', preview: 'Aa Bb Gg 123' },
+            { key: 'Outfit', name: 'Outfit', category: 'sans', family: "'Outfit', sans-serif", type: 'Premium Tech', preview: 'Aa Bb Gg 123' },
+            { key: 'Nunito', name: 'Nunito', category: 'sans', family: "'Nunito', sans-serif", type: 'Soft & Friendly', preview: 'Aa Bb Gg 123' },
+            { key: 'Raleway', name: 'Raleway', category: 'sans', family: "'Raleway', sans-serif", type: 'Elegant Modern', preview: 'Aa Bb Gg 123' },
+            { key: 'Arial', name: 'Arial', category: 'sans', family: "Arial, Helvetica, sans-serif", type: 'Crisp Neutral', preview: 'Aa Bb Gg 123' },
+            { key: 'Trebuchet MS', name: 'Trebuchet MS', category: 'sans', family: "'Trebuchet MS', 'Lucida Sans', sans-serif", type: 'Dynamic Sans', preview: 'Aa Bb Gg 123' },
+            { key: 'Century Gothic', name: 'Century Gothic', category: 'sans', family: "'Century Gothic', Arial, sans-serif", type: 'Geometric Standard', preview: 'Aa Bb Gg 123' },
+            // Classic & Editorial Serif
+            { key: 'Cambria', name: 'Cambria', category: 'serif', family: "Cambria, Georgia, 'Times New Roman', serif", type: 'Executive Serif', preview: 'Aa Bb Gg 123' },
+            { key: 'Times New Roman', name: 'Times New Roman', category: 'serif', family: "'Times New Roman', Times, serif", type: 'Classic Formal', preview: 'Aa Bb Gg 123' },
+            { key: 'Georgia', name: 'Georgia', category: 'serif', family: "Georgia, 'Times New Roman', serif", type: 'Editorial Serif', preview: 'Aa Bb Gg 123' },
+            { key: 'Garamond', name: 'Garamond', category: 'serif', family: "Garamond, 'EB Garamond', Georgia, serif", type: 'Literary Serif', preview: 'Aa Bb Gg 123' },
+            { key: 'Merriweather', name: 'Merriweather', category: 'serif', family: "'Merriweather', serif", type: 'High Legibility', preview: 'Aa Bb Gg 123' },
+            { key: 'Playfair Display', name: 'Playfair Display', category: 'serif', family: "'Playfair Display', Georgia, serif", type: 'High-Contrast Editorial', preview: 'Aa Bb Gg 123' },
+            { key: 'Lora', name: 'Lora', category: 'serif', family: "'Lora', Georgia, serif", type: 'Contemporary Serif', preview: 'Aa Bb Gg 123' },
+            { key: 'Libre Baskerville', name: 'Libre Baskerville', category: 'serif', family: "'Libre Baskerville', Georgia, serif", type: 'Traditional British', preview: 'Aa Bb Gg 123' },
+            { key: 'PT Serif', name: 'PT Serif', category: 'serif', family: "'PT Serif', Georgia, serif", type: 'Academic Formal', preview: 'Aa Bb Gg 123' },
+            { key: 'Palatino', name: 'Palatino', category: 'serif', family: "'Palatino Linotype', 'Book Antiqua', Palatino, serif", type: 'Refined Book Serif', preview: 'Aa Bb Gg 123' },
+            { key: 'Cinzel', name: 'Cinzel', category: 'serif', family: "'Cinzel', Georgia, serif", type: 'Classic Roman', preview: 'Aa Bb Gg 123' }
+        ];
+
+        function getThemeFont() {
+            return String(cvData.themeFont || '').trim();
+        }
+
+        function filterFontCategory(cat) {
+            activeFontCategory = cat || 'all';
+            document.querySelectorAll('.template-font-tab').forEach(tab => {
+                tab.classList.toggle('active', tab.getAttribute('data-cat') === activeFontCategory);
+            });
+            renderFontControls();
+        }
+
+        function renderFontControls() {
+            const fontGrid = document.getElementById('template-font-grid');
+            const current = getThemeFont();
+            if (fontGrid) {
+                const list = TEMPLATE_FONTS.filter(f => {
+                    if (activeFontCategory === 'all') return true;
+                    if (!f.key) return true; // Always show Default
+                    return f.category === activeFontCategory;
+                });
+
+                fontGrid.innerHTML = list.map(f => {
+                    const isActive = (f.key.toLowerCase() === current.toLowerCase()) || (!f.key && !current);
+                    return `
+                        <div class="template-font-card ${isActive ? 'active' : ''}" onclick="updateThemeFont('${f.key}')" style="${f.family ? `font-family:${f.family};` : ''}">
+                            <div class="template-font-name" style="${f.family ? `font-family:${f.family};` : ''}">${f.name}</div>
+                            <div class="template-font-preview">${f.type} &bull; ${f.preview}</div>
+                        </div>
+                    `;
+                }).join('');
+            }
+
+            const fontLabel = document.getElementById('current-font-name');
+            if (fontLabel) {
+                const match = TEMPLATE_FONTS.find(f => f.key.toLowerCase() === current.toLowerCase());
+                fontLabel.textContent = match ? match.name : (current || 'Default');
+            }
+        }
+
+        function updateThemeFont(key) {
+            cvData.themeFont = String(key || '').trim();
+            saveLocal();
+            renderFontControls();
+            postToFrame();
+        }
+
+        function resetThemeFont() {
+            cvData.themeFont = '';
+            saveLocal();
+            renderFontControls();
+            postToFrame();
+        }
+
+        function toggleColorDropdown(event) {
+            if (event) event.stopPropagation();
+            const fontMenu = document.getElementById('font-dropdown-menu');
+            if (fontMenu) fontMenu.classList.remove('open');
+            const colorMenu = document.getElementById('color-dropdown-menu');
+            if (colorMenu) {
+                const isOpen = colorMenu.classList.toggle('open');
+                if (isOpen) renderThemeControls();
+            }
+        }
+
+        function toggleFontDropdown(event) {
+            if (event) event.stopPropagation();
+            const colorMenu = document.getElementById('color-dropdown-menu');
+            if (colorMenu) colorMenu.classList.remove('open');
+            const fontMenu = document.getElementById('font-dropdown-menu');
+            if (fontMenu) {
+                const isOpen = fontMenu.classList.toggle('open');
+                if (isOpen) renderFontControls();
+            }
+        }
+
+        document.addEventListener('click', (e) => {
+            if (!e.target.closest('.floater-dropdown-wrap')) {
+                const colorMenu = document.getElementById('color-dropdown-menu');
+                const fontMenu = document.getElementById('font-dropdown-menu');
+                if (colorMenu) colorMenu.classList.remove('open');
+                if (fontMenu) fontMenu.classList.remove('open');
+            }
+        });
 
         function toggleTemplateSidebar(show) {
             const sidebar = document.getElementById('template-sidebar');
@@ -3144,7 +3298,6 @@
             if (show) {
                 sidebar.classList.add('open');
                 overlay.classList.add('open');
-                renderThemeControls();
                 renderTemplateCards();
             } else {
                 sidebar.classList.remove('open');
@@ -3292,6 +3445,8 @@
             if (!payload.personal) payload.personal = { name: "", tagline: "", contact: "", phone: "", email: "", linkedin: "", location: "", socialLinks: [] };
             if (!payload.personal.socialLinks) payload.personal.socialLinks = [];
             payload.themeAccent = normalizeHexColor(payload.themeAccent || cvData.themeAccent || '');
+            payload.themeFont = String(payload.themeFont || cvData.themeFont || '').trim();
+            payload.sectionTitles = cvData.sectionTitles || {};
             applyFormattedContact(payload);
             return payload;
         }

--- a/cv-builder/cv-styles.css
+++ b/cv-builder/cv-styles.css
@@ -1105,6 +1105,85 @@
             background: rgba(148, 163, 184, 0.15);
         }
 
+        .floater-dropdown-wrap {
+            position: relative;
+            display: inline-flex;
+            align-items: center;
+        }
+
+        .floater-dropdown-menu {
+            position: absolute;
+            top: calc(100% + 10px);
+            left: 50%;
+            transform: translateX(-50%) translateY(6px);
+            background: #ffffff;
+            border: 1px solid #e2e8f0;
+            border-radius: 18px;
+            box-shadow: 0 16px 36px rgba(15, 23, 42, 0.16), 0 4px 12px rgba(15, 23, 42, 0.08);
+            padding: 16px;
+            z-index: 1000;
+            opacity: 0;
+            pointer-events: none;
+            visibility: hidden;
+            transition: opacity 0.2s ease, transform 0.2s cubic-bezier(0.16, 1, 0.3, 1), visibility 0.2s;
+        }
+
+        .floater-dropdown-menu.open {
+            opacity: 1;
+            pointer-events: all;
+            visibility: visible;
+            transform: translateX(-50%) translateY(0);
+        }
+
+        .color-dropdown-menu {
+            width: 300px;
+        }
+
+        .font-dropdown-menu {
+            width: 360px;
+        }
+
+        .template-font-tabs {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            margin-bottom: 10px;
+        }
+
+        .template-font-tab {
+            padding: 4px 10px;
+            border-radius: 999px;
+            border: 1px solid #e2e8f0;
+            background: #f8fafc;
+            color: #64748b;
+            font-size: 11px;
+            font-weight: 600;
+            cursor: pointer;
+            transition: all 0.15s ease;
+        }
+
+        .template-font-tab:hover {
+            color: #1e293b;
+            background: #f1f5f9;
+        }
+
+        .template-font-tab.active {
+            border-color: #6366f1;
+            background: #6366f1;
+            color: #ffffff;
+        }
+
+        .floater-color-preview {
+            width: 13px;
+            height: 13px;
+            border-radius: 50%;
+            border: 1.5px solid rgba(0, 0, 0, 0.15);
+            background: #2F557F;
+            display: inline-block;
+            margin-right: 2px;
+            flex-shrink: 0;
+        }
+
         .undo-redo-pill {
             gap: 8px;
             cursor: default;
@@ -1464,6 +1543,68 @@
             font-size: 12px;
             font-weight: 700;
             white-space: nowrap;
+        }
+
+        .template-font-grid {
+            display: grid;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 8px;
+            max-height: 300px;
+            overflow-y: auto;
+            padding-right: 2px;
+        }
+
+        .template-font-grid::-webkit-scrollbar {
+            width: 4px;
+        }
+
+        .template-font-grid::-webkit-scrollbar-thumb {
+            background: #cbd5e1;
+            border-radius: 4px;
+        }
+
+        .template-font-card {
+            display: flex;
+            flex-direction: column;
+            align-items: flex-start;
+            justify-content: center;
+            padding: 8px 10px;
+            border-radius: 12px;
+            border: 1.5px solid #e2e8f0;
+            background: #ffffff;
+            cursor: pointer;
+            text-align: left;
+            transition: all 0.18s ease;
+            user-select: none;
+        }
+
+        .template-font-card:hover {
+            border-color: #93c5fd;
+            background: #f8fafc;
+            transform: translateY(-1px);
+        }
+
+        .template-font-card.active {
+            border-color: #6366f1;
+            background: #eff6ff;
+            box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.12);
+        }
+
+        .template-font-name {
+            font-size: 13px;
+            font-weight: 700;
+            color: #0f172a;
+            line-height: 1.2;
+        }
+
+        .template-font-preview {
+            font-size: 10.5px;
+            color: #64748b;
+            margin-top: 2px;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            width: 100%;
         }
 
         .template-sidebar-overlay {

--- a/cv-builder/elegant-grid.html
+++ b/cv-builder/elegant-grid.html
@@ -515,7 +515,7 @@
             <div class="sortable-section" data-section-id="experience">
                 <div class="section-header">Work Experience</div>
                 <div id="experience-list">
-                    <!-- One bordered table per stint: grey title bar + "Key Areas of Exposure" row -->
+                    <!-- One bordered table per stint: grey title bar + Department/Category row -->
                     <table class="exp-entry template" style="display:none;">
                         <colgroup>
                             <col class="exp-l">
@@ -527,14 +527,13 @@
                                     <div class="exp-titlebar-inner">
                                         <span class="exp-titletext"><span class="exp-role"
                                                 data-field="role"></span><span class="exp-firm"
-                                                data-field="company"></span><span class="exp-cat"
-                                                data-field="category"></span></span>
+                                                data-field="company"></span></span>
                                         <span class="exp-date" data-field="dates"></span>
                                     </div>
                                 </td>
                             </tr>
                             <tr>
-                                <td class="exp-keylabel">Key Areas of Exposure:</td>
+                                <td class="exp-keylabel" data-field="category"></td>
                                 <td class="exp-keybody">
                                     <div class="exp-intro" data-field="intro"></div>
                                     <ul data-list="bullets"></ul>

--- a/cv-builder/grid-docket.html
+++ b/cv-builder/grid-docket.html
@@ -216,6 +216,12 @@ table.ledger-table td, table.ledger-table th {
   color: var(--text-dark);
 }
 
+.role-title:empty,
+.exp-category:empty,
+.exp-intro:empty {
+  display: none;
+}
+
 /* Academic Qualifications Table */
 .acad-table {
   width: 100%;
@@ -401,8 +407,12 @@ table.ledger-table td, table.ledger-table th {
           </colgroup>
           <tbody>
             <tr class="sub-header-row">
-              <td class="company-name" data-field="company">Article Assistant - Deloitte Haskins & Sells</td>
-              <td class="date-range" data-field="dates" style="text-align: right;">September 2023 - August 2025</td>
+              <td colspan="2" class="sub-header-cell">
+                <div class="sub-header-content" style="display: flex; justify-content: space-between; align-items: baseline; width: 100%;">
+                  <span class="company-name" data-field="company">Article Assistant - Deloitte Haskins & Sells</span>
+                  <span class="date-range" data-field="dates" style="text-align: right; white-space: nowrap; flex-shrink: 0; margin-left: calc(10px * var(--cs));">September 2023 - August 2025</span>
+                </div>
+              </td>
             </tr>
             <tr>
               <td class="label-cell">

--- a/cv-builder/index.html
+++ b/cv-builder/index.html
@@ -241,6 +241,11 @@
                 <summary>Career Objective</summary>
                 <div class="section-body">
                     <div class="form-group">
+                        <label for="inp-title-summary">Section Title (optional)</label>
+                        <input type="text" class="form-control" id="inp-title-summary" name="inp-title-summary"
+                            placeholder="Default: Career Objective" oninput="updateSectionTitle('summary', this.value)">
+                    </div>
+                    <div class="form-group">
                         <div
                             style="display:flex; align-items:center; justify-content:space-between; margin-bottom:6px;">
                             <label style="margin-bottom:0;" for="inp-summary">Objective / Summary</label>
@@ -270,6 +275,11 @@
                         style="font-size:10px; padding:4px 8px;">Table format</button>
                 </summary>
                 <div class="section-body">
+                    <div class="form-group">
+                        <label for="inp-title-education">Section Title (optional)</label>
+                        <input type="text" class="form-control" id="inp-title-education" name="inp-title-education"
+                            placeholder="Default: Education" oninput="updateSectionTitle('education', this.value)">
+                    </div>
                     <div id="education-format-panel-wrap" class="table-format-panel-wrap" aria-hidden="true">
                         <div class="table-format-panel-head">
                             <div>
@@ -299,6 +309,11 @@
                     <span>Experience / Articleship</span>
                 </summary>
                 <div class="section-body">
+                    <div class="form-group">
+                        <label for="inp-title-experience">Section Title (optional)</label>
+                        <input type="text" class="form-control" id="inp-title-experience" name="inp-title-experience"
+                            placeholder="Default: Experience / Articleship" oninput="updateSectionTitle('experience', this.value)">
+                    </div>
                     <div id="exp-container"></div>
                     <button class="btn-dashed" onclick="addExperience()">
                         <svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2"
@@ -314,6 +329,11 @@
             <details data-section="projects">
                 <summary>Projects</summary>
                 <div class="section-body">
+                    <div class="form-group">
+                        <label for="inp-title-projects">Section Title (optional)</label>
+                        <input type="text" class="form-control" id="inp-title-projects" name="inp-title-projects"
+                            placeholder="Default: Projects" oninput="updateSectionTitle('projects', this.value)">
+                    </div>
                     <div class="form-group">
                         <div
                             style="display:flex; align-items:center; justify-content:space-between; margin-bottom:6px;">
@@ -350,6 +370,11 @@
                     </div>
                 </summary>
                 <div class="section-body">
+                    <div class="form-group">
+                        <label for="inp-title-certifications">Section Title (optional)</label>
+                        <input type="text" class="form-control" id="inp-title-certifications" name="inp-title-certifications"
+                            placeholder="Default: Certifications" oninput="updateSectionTitle('certifications', this.value)">
+                    </div>
                     <div id="section-label-panel-certifications" class="table-format-panel-wrap" aria-hidden="true">
                     </div>
                     <div id="cert-container"></div>
@@ -373,6 +398,11 @@
                     </div>
                 </summary>
                 <div class="section-body">
+                    <div class="form-group">
+                        <label for="inp-title-achievements">Section Title (optional)</label>
+                        <input type="text" class="form-control" id="inp-title-achievements" name="inp-title-achievements"
+                            placeholder="Default: Achievements &amp; Awards" oninput="updateSectionTitle('achievements', this.value)">
+                    </div>
                     <div id="section-label-panel-achievements" class="table-format-panel-wrap" aria-hidden="true"></div>
                     <div class="form-group">
                         <div
@@ -410,6 +440,11 @@
                     </div>
                 </summary>
                 <div class="section-body">
+                    <div class="form-group">
+                        <label for="inp-title-leadership">Section Title (optional)</label>
+                        <input type="text" class="form-control" id="inp-title-leadership" name="inp-title-leadership"
+                            placeholder="Default: Leadership" oninput="updateSectionTitle('leadership', this.value)">
+                    </div>
                     <div id="section-label-panel-leadership" class="table-format-panel-wrap" aria-hidden="true"></div>
                     <div class="form-group">
                         <div
@@ -447,6 +482,11 @@
                     </div>
                 </summary>
                 <div class="section-body">
+                    <div class="form-group">
+                        <label for="inp-title-interests">Section Title (optional)</label>
+                        <input type="text" class="form-control" id="inp-title-interests" name="inp-title-interests"
+                            placeholder="Default: Interests &amp; Hobbies" oninput="updateSectionTitle('interests', this.value)">
+                    </div>
                     <div id="section-label-panel-interests" class="table-format-panel-wrap" aria-hidden="true"></div>
                     <div class="form-group">
                         <div
@@ -484,6 +524,11 @@
                     </div>
                 </summary>
                 <div class="section-body">
+                    <div class="form-group">
+                        <label for="inp-title-skills">Section Title (optional)</label>
+                        <input type="text" class="form-control" id="inp-title-skills" name="inp-title-skills"
+                            placeholder="Default: Skills" oninput="updateSectionTitle('skills', this.value)">
+                    </div>
                     <div id="section-label-panel-skills" class="table-format-panel-wrap" aria-hidden="true"></div>
                     <div class="chip-container" id="skills-chips"></div>
                     <div class="form-group">
@@ -536,6 +581,61 @@
                     <path d="M6 9l6 6 6-6" />
                 </svg>
             </button>
+            <div class="floater-dropdown-wrap" id="color-dropdown-wrap">
+                <button class="floater-pill" id="btn-color-floater" onclick="toggleColorDropdown(event)">
+                    <span class="template-label">Color</span>
+                    <span class="floater-color-preview" id="current-color-swatch"></span>
+                    <span id="current-color-name"
+                        style="font-size: 13px; font-weight: 600; color: var(--text-main);">Default</span>
+                    <svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                        <path d="M6 9l6 6 6-6" />
+                    </svg>
+                </button>
+                <div class="floater-dropdown-menu color-dropdown-menu" id="color-dropdown-menu" onclick="event.stopPropagation()">
+                    <div class="template-theme-head">
+                        <div>
+                            <div class="template-theme-title">Color Theme</div>
+                            <div class="template-theme-subtitle">Use presets or custom color</div>
+                        </div>
+                        <button type="button" class="template-theme-reset" onclick="resetThemeAccent()">Default</button>
+                    </div>
+                    <div class="template-theme-swatches" id="template-theme-swatches"></div>
+                    <div class="template-theme-custom">
+                        <label for="theme-accent-picker">Custom RGB</label>
+                        <div class="template-theme-custom-row">
+                            <input type="color" id="theme-accent-picker" onchange="updateThemeAccent(this.value)">
+                            <input type="text" id="theme-accent-value" class="form-control" placeholder="#2F557F"
+                                oninput="updateThemeAccentFromText(this.value)">
+                            <div class="template-theme-chip" id="theme-accent-chip">Accent</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="floater-dropdown-wrap" id="font-dropdown-wrap">
+                <button class="floater-pill" id="btn-font-floater" onclick="toggleFontDropdown(event)">
+                    <span class="template-label">Font</span>
+                    <span id="current-font-name"
+                        style="font-size: 13px; font-weight: 600; color: var(--text-main);">Default</span>
+                    <svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                        <path d="M6 9l6 6 6-6" />
+                    </svg>
+                </button>
+                <div class="floater-dropdown-menu font-dropdown-menu" id="font-dropdown-menu" onclick="event.stopPropagation()">
+                    <div class="template-theme-head">
+                        <div>
+                            <div class="template-theme-title">Typography &amp; Font</div>
+                            <div class="template-theme-subtitle">Select font or use template default</div>
+                        </div>
+                        <button type="button" class="template-theme-reset" onclick="resetThemeFont()">Default</button>
+                    </div>
+                    <div class="template-font-tabs" id="template-font-tabs">
+                        <button type="button" class="template-font-tab active" data-cat="all" onclick="filterFontCategory('all')">All</button>
+                        <button type="button" class="template-font-tab" data-cat="sans" onclick="filterFontCategory('sans')">Sans-Serif</button>
+                        <button type="button" class="template-font-tab" data-cat="serif" onclick="filterFontCategory('serif')">Serif</button>
+                    </div>
+                    <div class="template-font-grid" id="template-font-grid"></div>
+                </div>
+            </div>
             <button class="floater-pill" onclick="toggleReorderDrawer(true)">
                 <span class="template-label">Layout</span>
                 <span style="font-size: 13px; font-weight: 600; color: var(--text-main);">Reorder</span>
@@ -1532,25 +1632,6 @@
         <div class="template-sidebar-header">
             <h3>Choose Template</h3>
             <button class="template-sidebar-close" onclick="toggleTemplateSidebar(false)">×</button>
-        </div>
-        <div class="template-theme-panel">
-            <div class="template-theme-head">
-                <div>
-                    <div class="template-theme-title">Color Theme</div>
-                    <div class="template-theme-subtitle">Use presets or pick any accent color</div>
-                </div>
-                <button type="button" class="template-theme-reset" onclick="resetThemeAccent()">Default</button>
-            </div>
-            <div class="template-theme-swatches" id="template-theme-swatches"></div>
-            <div class="template-theme-custom">
-                <label for="theme-accent-picker">Custom RGB</label>
-                <div class="template-theme-custom-row">
-                    <input type="color" id="theme-accent-picker" onchange="updateThemeAccent(this.value)">
-                    <input type="text" id="theme-accent-value" class="form-control" placeholder="#2F557F"
-                        oninput="updateThemeAccentFromText(this.value)">
-                    <div class="template-theme-chip" id="theme-accent-chip">Accent</div>
-                </div>
-            </div>
         </div>
         <div class="template-grid" id="template-grid">
             <!-- Cards injected by JS -->


### PR DESCRIPTION
# Pull Request: Typography Font Picker, Toolbar Dropdown Controls, Section Title Customization & Template Fixes

##  Summary of Changes

This PR introduces major enhancements to the **CV Builder**, including a Typography / Font Picker system with 25 curated resume fonts, interactive toolbar dropdown menus for Color and Font customization, custom Section Title renaming for all built-in sections, and critical template rendering bug fixes.

---

##  Key Features & Enhancements

### 1. Typography & Font Picker System
- **25 Curated Professional Fonts**:
  - **Sans-Serif (13)**: Calibri, Inter, Roboto, Open Sans, Lato, Montserrat, Poppins, Outfit, Nunito, Raleway, Arial, Trebuchet MS, Century Gothic.
  - **Serif (11)**: Cambria, Times New Roman, Georgia, Garamond / EB Garamond, Merriweather, Playfair Display, Lora, Libre Baskerville, PT Serif, Palatino, Cinzel.
  - **Template Default**: Restores each template's native font family.
- **Category Filter Tabs**: Added **All**, **Sans-Serif**, and **Serif** tabs in the font dropdown for quick filtering.
- **Dynamic Webfont Loader**: Automated Google Fonts stylesheet injection for web fonts with `document.fonts.ready` triggers to automatically recalculate layout fit and page scaling upon font loading.
- **Scoped Application**: Scoped font styles to `#cv-page` while protecting FontAwesome and SVG icons from being overridden.

### 2. Toolbar Dropdown Controls & Clean Template Sidebar
- **Floater Pill Dropdowns**:
  - Refactored **Color** and **Font** into dropdown popovers directly anchored to their top floater toolbar pills.
  - Added click-outside dismissal (`document.addEventListener('click', ...)`) for smooth UX.
  - Added a live circular color swatch indicator on the Color toolbar pill.
- **Streamlined Template Drawer**:
  - Removed the inline Color Theme and Typography panels from the "Choose Template" sidebar (`#template-sidebar`), keeping the drawer uncluttered and exclusively focused on template selection cards.

### 3.  Section Title Customization (Universal Across Built-in Sections)
- **Customizable Section Headings**:
  - Added an optional **Section Title** input field to the top of all 9 core built-in sections:
    - **Career Objective / Summary** (e.g., *Executive Summary*, *Professional Profile*)
    - **Education** (e.g., *Academic Background*, *Educational Qualifications*)
    - **Experience / Articleship** (e.g., *Articleship Experience*, *Professional Experience*, *Industrial Training*)
    - **Projects** (e.g., *Key Engagements*, *Major Assignments*)
    - **Certifications** (e.g., *Professional Credentials*, *Certificates & Courses*)
    - **Achievements & Awards** (e.g., *Key Achievements*, *Honors & Awards*)
    - **Leadership** (e.g., *Positions of Responsibility*, *Extracurricular Leadership*)
    - **Interests & Hobbies** (e.g., *Areas of Interest*, *Personal Pursuits*)
    - **Skills** (e.g., *Core Competencies*, *Technical & Domain Skills*)
- **Graceful Fallback**: If a Section Title is left empty or reset, templates automatically revert to their native default title (cached via `data-default-title`).
- **Dynamic Sync**: Custom section titles instantly sync with the **Layout Reorder** drawer and reflect across template switches.

### 4.  Bug Fixes & Template Refinements
- **Elegant Grid Exposure Category**:
  - Replaced hardcoded "Key Areas of Exposure:" text in `elegant-grid.html` with dynamic `data-field="category"`.
- **Grid Docket Subheader Row**:
  - Fixed the full-width subheader spanning in `grid-docket.html` to eliminate the 26% vertical column line glitch.
- **Project Bullet Points**:
  - Fixed a bug where project bullet points did not render when the project `description` field was left empty.
- **Fixed Runtime Reference Errors**:
  - Fixed a silent failure on font selection by removing undefined history calls and using proper state persistence (`saveLocal()` and `postToFrame()`).

---

## Files Modified

| File | Changes |
| :--- | :--- |
| [`cv-builder/index.html`](file:///d:/Intern/msc/mystudentclub/cv-builder/index.html) | Added Color and Font dropdown menus to `.template-floater`; added Section Title input fields to all 9 built-in sections; removed theme/font panels from `#template-sidebar`. |
| [`cv-builder/cv-styles.css`](file:///d:/Intern/msc/mystudentclub/cv-builder/cv-styles.css) | Added `.floater-dropdown-wrap`, `.floater-dropdown-menu`, `.template-font-tabs`, `.template-font-tab`, `.template-font-grid`, `.template-font-card`, and `.floater-color-preview` styles. |
| [`cv-builder/cv-script.js`](file:///d:/Intern/msc/mystudentclub/cv-builder/cv-script.js) | Implemented dropdown toggle logic, outside click listeners, 25-font registry, category filtering, `sectionTitles` data management, `updateSectionTitle()`, and reorder drawer label sync. |
| [`cv-builder/cv-common.js`](file:///d:/Intern/msc/mystudentclub/cv-builder/cv-common.js) | Added `applyTemplateFont()` with Google Font loader, `applySectionTitles()` for dynamic section heading overrides with default fallback, and fixed project bullet rendering. |
| [`cv-builder/elegant-grid.html`](file:///d:/Intern/msc/mystudentclub/cv-builder/elegant-grid.html) | Replaced hardcoded exposure title with dynamic `data-field="category"`. |
| [`cv-builder/grid-docket.html`](file:///d:/Intern/msc/mystudentclub/cv-builder/grid-docket.html) | Fixed subheader cell structure and full-width borders. |

---

## Verification & Testing

- [x] **Font Switching**: Verified all 25 fonts render properly; Google Fonts load asynchronously and re-trigger scaling/shrinking.
- [x] **Font Filters**: Verified **All**, **Sans-Serif**, and **Serif** tabs filter cards accurately.
- [x] **Color Dropdown**: Tested preset swatches and custom RGB picker; updates live preview and persists on refresh.
- [x] **Section Title Customization**: Tested renaming core sections (e.g., "Work Experience" $\rightarrow$ "Articleship Experience"); verified reorder drawer and preview frame update immediately; verified empty titles restore default template headings.
- [x] **Template Rendering**: Verified Elegant Grid and Grid Docket render clean layouts without visual artifacts.
